### PR TITLE
build(renderer): align raijin renderer contract

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6785,6 +6785,7 @@ const RAW_RUNTIME_STATE =
           ["@types/react", "npm:17.0.8"],\
           ["@types/react-dom", "npm:16.9.8"],\
           ["@ui/theme", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#workspace:ui/theme"],\
+          ["axios", "npm:0.21.4"],\
           ["body-parser", "npm:1.19.0"],\
           ["connect-redis", "npm:3.4.2"],\
           ["cookie", "npm:0.4.1"],\

--- a/email/entrypoints/renderer/next.config.js
+++ b/email/entrypoints/renderer/next.config.js
@@ -1,3 +1,6 @@
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
 const { withExtractIntlMessages } = require('@atls/next-config-with-extract-intl-messages')
 const withPlugins = require('next-compose-plugins')
 const withImages = require('next-images')
@@ -16,9 +19,27 @@ const withWorkspaces = (() => {
 const nextConfig = {
   experimental: {
     externalDir: true,
+    outputFileTracingRoot: join(__dirname, '../../..'),
+    outputStandalone: true,
     swcFileReading: false,
     workerThreads: true,
     esmExternals: 'loose',
+  },
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^\.\.?\/.*\.js$/, (resource) => {
+        const request = resource.request.slice(0, -3)
+
+        for (const extension of ['.tsx', '.ts', '.jsx']) {
+          if (existsSync(join(resource.context, `${request}${extension}`))) {
+            resource.request = `${request}${extension}`
+            break
+          }
+        }
+      })
+    )
+
+    return config
   },
 }
 

--- a/email/entrypoints/renderer/package.json
+++ b/email/entrypoints/renderer/package.json
@@ -4,8 +4,8 @@
   "license": "BSD-3-Clause",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn service build && yarn next build src && cp -r src/.next dist/.next",
-    "dev": "yarn next dev src",
+    "build": "yarn renderer build",
+    "dev": "yarn renderer dev",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/identity/entrypoints/renderer/next.config.js
+++ b/identity/entrypoints/renderer/next.config.js
@@ -1,3 +1,6 @@
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
 const { withExtractIntlMessages } = require('@atls/next-config-with-extract-intl-messages')
 const withPlugins = require('next-compose-plugins')
 const withImages = require('next-images')
@@ -16,6 +19,8 @@ const withWorkspaces = (() => {
 const nextConfig = {
   experimental: {
     externalDir: true,
+    outputFileTracingRoot: join(__dirname, '../../..'),
+    outputStandalone: true,
     swcFileReading: false,
     workerThreads: true,
     esmExternals: 'loose',
@@ -27,6 +32,22 @@ const nextConfig = {
         destination: 'http://kratos:4433/:path*',
       },
     ]
+  },
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^\.\.?\/.*\.js$/, (resource) => {
+        const request = resource.request.slice(0, -3)
+
+        for (const extension of ['.tsx', '.ts', '.jsx']) {
+          if (existsSync(join(resource.context, `${request}${extension}`))) {
+            resource.request = `${request}${extension}`
+            break
+          }
+        }
+      })
+    )
+
+    return config
   },
 }
 

--- a/identity/entrypoints/renderer/package.json
+++ b/identity/entrypoints/renderer/package.json
@@ -4,8 +4,8 @@
   "license": "BSD-3-Clause",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn service build && yarn next build src && cp -r src/.next dist/.next",
-    "dev": "yarn next dev src",
+    "build": "yarn renderer build",
+    "dev": "yarn renderer dev",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/identity/entrypoints/renderer/package.json
+++ b/identity/entrypoints/renderer/package.json
@@ -25,6 +25,7 @@
     "@ory/kratos-client": "0.8.2-alpha.1",
     "@protos/common": "0.3.1",
     "@protos/identity": "0.3.1",
+    "axios": "0.21.4",
     "body-parser": "1.19.0",
     "connect-redis": "3.4.2",
     "cookie-parser": "1.4.4",

--- a/site/entrypoints/renderer/next.config.js
+++ b/site/entrypoints/renderer/next.config.js
@@ -1,3 +1,6 @@
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
 const { withExtractIntlMessages } = require('@atls/next-config-with-extract-intl-messages')
 const withPlugins = require('next-compose-plugins')
 const withImages = require('next-images')
@@ -16,9 +19,27 @@ const withWorkspaces = (() => {
 const nextConfig = {
   experimental: {
     externalDir: true,
+    outputFileTracingRoot: join(__dirname, '../../..'),
+    outputStandalone: true,
     swcFileReading: false,
     workerThreads: true,
     esmExternals: 'loose',
+  },
+  webpack: (config, { webpack }) => {
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(/^\.\.?\/.*\.js$/, (resource) => {
+        const request = resource.request.slice(0, -3)
+
+        for (const extension of ['.tsx', '.ts', '.jsx']) {
+          if (existsSync(join(resource.context, `${request}${extension}`))) {
+            resource.request = `${request}${extension}`
+            break
+          }
+        }
+      })
+    )
+
+    return config
   },
 }
 

--- a/site/entrypoints/renderer/package.json
+++ b/site/entrypoints/renderer/package.json
@@ -4,8 +4,8 @@
   "license": "BSD-3-Clause",
   "main": "src/index.ts",
   "scripts": {
-    "build": "yarn service build && yarn next build src && cp -r src/.next dist/.next",
-    "dev": "yarn next dev src",
+    "build": "yarn renderer build",
+    "dev": "yarn renderer dev",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3594,6 +3594,7 @@ __metadata:
     "@types/react": "npm:16.9.43"
     "@types/react-dom": "npm:16.9.8"
     "@ui/theme": "npm:0.0.5"
+    axios: "npm:0.21.4"
     body-parser: "npm:1.19.0"
     connect-redis: "npm:3.4.2"
     cookie: "npm:^0.4.1"
@@ -9890,6 +9891,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:0.21.4, axios@npm:^0.21.1, axios@npm:^0.21.4":
+  version: 0.21.4
+  resolution: "axios@npm:0.21.4"
+  dependencies:
+    follow-redirects: "npm:^1.14.0"
+  checksum: 10/da644592cb6f8f9f8c64fdabd7e1396d6769d7a4c1ea5f8ae8beb5c2eb90a823e3a574352b0b934ac62edc762c0f52647753dc54f7d07279127a7e5c4cd20272
+  languageName: node
+  linkType: hard
+
 "axios@npm:0.24.0":
   version: 0.24.0
   resolution: "axios@npm:0.24.0"
@@ -9905,15 +9915,6 @@ __metadata:
   dependencies:
     follow-redirects: "npm:^1.14.8"
   checksum: 10/02863f4a4fd4e43ad6e0c8bc9d1359a0863c43cc57bda42ea21dfce34681e3211df193b2bf2e8ee10b2c3870ab8d6bed38a3cf80cd6e8ee17749b7d73ccd4752
-  languageName: node
-  linkType: hard
-
-"axios@npm:^0.21.1, axios@npm:^0.21.4":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10/da644592cb6f8f9f8c64fdabd7e1396d6769d7a4c1ea5f8ae8beb5c2eb90a823e3a574352b0b934ac62edc762c0f52647753dc54f7d07279127a7e5c4cd20272
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Таска
- Close atls/planning#628

## Как проверять
### Основной сценарий
1. Контекст: renderer entrypoints после перехода на Raijin renderer contract.
Действие: выполнить `yarn install --immutable`, затем `yarn workspace @site/renderer-entrypoint renderer build`, `yarn workspace @identity/renderer-entrypoint renderer build`, `yarn workspace @email/renderer-entrypoint renderer build`.
Ожидаемый результат: установка проходит через PnP; все три renderer build доходят до `Copy standalone files`, `Move server start files` и завершаются без ошибок.

### Дополнительный сценарий
1. Контекст: imagepack-совместимость renderer workspace.
Действие: выполнить `yarn workspace @site/renderer-entrypoint image pack --help`.
Ожидаемый результат: доступна штатная команда `yarn image pack ...`; workspace использует build script через `renderer build`.

## Пруфы
- `yarn install --immutable`
```text
➤ YN0000: · Done with warnings in 1s 40ms
```
- `renderer build`
```text
@site/renderer-entrypoint: Done with warnings in 7s 862ms
@identity/renderer-entrypoint: Done with warnings in 8s 120ms
@email/renderer-entrypoint: Done with warnings in 5s 429ms
```
- `yarn workspace @site/renderer-entrypoint image pack --help`
```text
$ yarn image pack [-r,--registry #0] [-t,--tag-policy #0] [-p,--publish] [--platform #0]
```
