### PR TITLE
fix(common): reduce serenity dev compose memory overhead

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,14 @@ services:
 
   yarn:
     image: node:24
+    init: true
     working_dir: /workspace
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache
-    entrypoint: yarn
+    entrypoint: ['/workspace/.yarn/bin/yarn']
+    profiles:
+      - tools
 
   elastic:
     image: elasticsearch:7.17.0
@@ -147,15 +150,17 @@ services:
 
   site:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/site/entrypoints/renderer
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @site/renderer-entrypoint dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - renderer
+      - dev
     environment:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-      - NODE_ICU_DATA=/workspace/node_modules/full-icu
       - PUBLIC_GATEWAY_URL=${PUBLIC_GATEWAY_URL}
     depends_on:
       - oathkeeper
@@ -169,15 +174,17 @@ services:
 
   site-local:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/site/entrypoints/renderer
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @site/renderer-entrypoint dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - renderer
+      - dev
     environment:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-      - NODE_ICU_DATA=/workspace/node_modules/full-icu
       - PUBLIC_GATEWAY_URL=http://localhost:4000/
       - DEV_AUTH_TOKEN=${DEV_AUTH_TOKEN}
       - DEV_AUTH_USER=${DEV_AUTH_USER}
@@ -191,12 +198,15 @@ services:
 
   identity:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/identity/entrypoints/renderer
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @identity/renderer-entrypoint dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - renderer
+      - dev
     environment:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - KRATOS_PUBLIC_URL=http://kratos:4433/
@@ -222,12 +232,15 @@ services:
 
   cookie-store:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/identity/entrypoints/renderer
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @identity/renderer-entrypoint dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - renderer
+      - dev
     environment:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - OAUTH_AUTHORIZATION_URL=https://sso.serenity.local.atls.tech/oauth2/auth
@@ -243,15 +256,17 @@ services:
 
   email:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/email/entrypoints/renderer
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @email/renderer-entrypoint dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - renderer
+      - dev
     environment:
       - NODE_TLS_REJECT_UNAUTHORIZED=0
-      - NODE_ICU_DATA=/workspace/node_modules/full-icu
       - PUBLIC_GATEWAY_URL=${PUBLIC_GATEWAY_URL}
       - WEB_VERSION_URL=https://email.serenity.local.atls.tech/s
       - ACCOUNTS_URL=https://accounts.serenity.local.atls.tech
@@ -267,11 +282,17 @@ services:
 
   public-gateway:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/public-gateway/app
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @public-gateway/app dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
+    environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
     depends_on:
       - oathkeeper
       - catalog-service
@@ -284,12 +305,17 @@ services:
 
   private-gateway:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/private-gateway/app
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @private-gateway/app dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
+    environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
     ports:
       - 3001:3000
     depends_on:
@@ -297,13 +323,17 @@ services:
 
   catalog-service:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/catalog/service
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @catalog/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -315,13 +345,17 @@ services:
 
   identity-service:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/identity/service
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @identity/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - KRATOS_PUBLIC_URL=http://kratos:4433/
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
@@ -333,13 +367,17 @@ services:
 
   mailer-service:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/mailer/service
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @mailer/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -352,12 +390,17 @@ services:
 
   collaboration:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/collaboration/service
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @collaboration/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -372,12 +415,17 @@ services:
 
   hits:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/hits/service
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @hits/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -392,12 +440,17 @@ services:
 
   portfolio:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/portfolio/service
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @portfolio/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -412,12 +465,17 @@ services:
 
   search-service:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/search/service
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @search/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -430,13 +488,17 @@ services:
 
   files-service:
     image: node:24-alpine
-    working_dir: /workspace
+    init: true
+    working_dir: /workspace/files/service
     volumes:
       - ./:/workspace
-      - modules:/workspace/node_modules
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
-    entrypoint: yarn workspace @files/service dev
+    entrypoint:
+      - /workspace/.yarn/bin/yarn
+      - service
+      - dev
     environment:
+      - NODE_OPTIONS=--require=/workspace/.pnp.cjs --loader=file:///workspace/.pnp.loader.mjs
       - DB_HOST=${DB_HOST:-db}
       - DB_NAME=${DB_NAME:-db}
       - DB_USERNAME=${DB_USERNAME:-postgres}
@@ -454,11 +516,6 @@ services:
       - db
     extra_hosts:
       - 's3.serenity.local.atls.tech:172.16.101.99'
-
-volumes:
-  modules:
-  yarncache:
-  unplugged:
 
 networks:
   traefik:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache
-    entrypoint: ['/workspace/.yarn/bin/yarn']
+    entrypoint: ['yarn']
     profiles:
       - tools
 
@@ -156,7 +156,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - renderer
       - dev
     environment:
@@ -180,7 +180,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - renderer
       - dev
     environment:
@@ -204,7 +204,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - renderer
       - dev
     environment:
@@ -238,7 +238,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - renderer
       - dev
     environment:
@@ -262,7 +262,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - renderer
       - dev
     environment:
@@ -288,7 +288,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -311,7 +311,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -329,7 +329,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -351,7 +351,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -373,7 +373,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -396,7 +396,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -421,7 +421,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -446,7 +446,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -471,7 +471,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:
@@ -494,7 +494,7 @@ services:
       - ./:/workspace
       - ../.yarn/berry/cache:/.yarn/berry/cache:ro
     entrypoint:
-      - /workspace/.yarn/bin/yarn
+      - yarn
       - service
       - dev
     environment:


### PR DESCRIPTION
## Таска

Refs atls/planning#540

## Что сделано

- Убран `modules:/workspace/node_modules` из dev-контейнеров: текущий compose больше не монтирует legacy `node_modules` volume в PnP-контур.
- Helper `yarn` вынесен из default compose в profile `tools`, чтобы пустой `docker compose up` не запускал `yarn install` и не ловил OOM на вспомогательном контейнере.
- Node dev-контейнеры переведены на запуск штатных Raijin-команд из директории workspace-пакета: `yarn service dev` / `yarn renderer dev`, без `yarn workspace <pkg> <script>` trampoline.
- Для backend/gateway `service dev` задан PnP `NODE_OPTIONS`, чтобы Raijin `plugin-service` не уходил в proxy child Yarn.
- Для Node dev-контейнеров включён `init: true`, чтобы Docker корректно reaped/forwarded child-процессы webpack/app runtime.

## Как проверять

- `docker compose config --quiet`
- `git diff --check`
- `docker compose up -d --remove-orphans`
- `docker compose ps -a`
- `docker stats --no-stream ...`

## Фактическая проверка

- До правки: default compose ловил OOM: `serenity-yarn-1` `Exited 137` с `OOMKilled=true`, `public-gateway` `Exited 129` с `OOMKilled=true`; baseline Node/watch контейнеров был порядка 430-760 MiB на сервис плюс лишний `yarn` helper.
- После правки: backend/gateway default compose держался после warmup без runtime `OOMKilled=true`; `yarn` helper больше не входит в default profile.
- Контрольный `catalog-service` с контрактным `entrypoint: yarn`: процессное дерево стало `docker-init -> yarn -> yarn-remote service dev -> app child`; Raijin proxy child Yarn не вернулся благодаря PnP `NODE_OPTIONS`.
- Warmup default compose: backend/gateway были running; обычные сервисы держали примерно 150-580 MiB, gateways оставались тяжёлыми, до 1.4-1.6 GiB на watch-прогреве.

## Не закрыто этим PR

- `site-local`, `identity`, `email` renderer-контейнеры завершаются `Exited (0)` на `yarn renderer dev`; smoke frontend не считается пройденным.
- Gateway watch-процессы всё ещё тяжёлые; #540 оставлен открытым для дальнейшего снижения dev-runtime бюджета.
