### PR TITLE
fix(app): align backend runtime scripts

### DIFF
--- a/catalog/service/package.json
+++ b/catalog/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",

--- a/collaboration/service/package.json
+++ b/collaboration/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",

--- a/files/service/package.json
+++ b/files/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",

--- a/hits/app/package.json
+++ b/hits/app/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@hits/commands": "0.0.1",

--- a/hits/service/package.json
+++ b/hits/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",

--- a/identity/service/package.json
+++ b/identity/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atlantis-lab/nestjs-map-errors-interceptor": "0.1.4",

--- a/mailer/service/package.json
+++ b/mailer/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@identity/domain": "workspace:^",

--- a/portfolio/service/package.json
+++ b/portfolio/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",

--- a/search/service/package.json
+++ b/search/service/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "$PROJECT_CWD/.yarn/bin/yarn service build",
-    "dev": "$PROJECT_CWD/.yarn/bin/yarn service dev",
-    "start": "node dist/index.js"
+    "build": "yarn service build",
+    "dev": "yarn service dev",
+    "start": "yarn node dist/index.js"
   },
   "dependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",


### PR DESCRIPTION
## Таска
- Close atls/planning#640

## Как проверять
### До фикса
1. Контекст: backend service package scripts
Действие: открыть `catalog/service`, `collaboration/service`, `files/service`, `hits/service`, `hits/app`, `identity/service`, `mailer/service`, `portfolio/service`, `search/service` package scripts.
Ожидаемый результат: До фикса `build`/`dev` идут через прямой `$PROJECT_CWD/.yarn/bin/yarn`, `start` идёт через прямой `node dist/index.js`.

### После фикса
1. Контекст: backend service package scripts
Действие: открыть те же backend package scripts.
Ожидаемый результат: После фикса `build`/`dev` используют штатные `yarn service build/dev`, `start` использует PnP-aware `yarn node dist/index.js`.

2. Контекст: backend service build
Действие: выполнить последовательные сборки затронутых backend workspaces через `yarn workspace <name> build`.
Ожидаемый результат: Все затронутые backend workspaces собираются через штатную Raijin/Yarn команду без прямых node/bundle обходов.

## Пруфы
- `rg -n '\$PROJECT_CWD/\.yarn/bin/yarn|"start": "node dist/index\.js"' catalog/service collaboration/service files/service hits/service hits/app identity/service mailer/service portfolio/service search/service --glob 'package.json'` -> совпадений нет.
- `yarn workspace @catalog/service build` -> exit 0.
- `yarn workspace @collaboration/service build` -> exit 0.
- `yarn workspace @files/service build` -> exit 0.
- `yarn workspace @hits/service build` -> exit 0.
- `yarn workspace @hits/app build` -> exit 0.
- `yarn workspace @identity/service build` -> exit 0.
- `yarn workspace @mailer/service build` -> exit 0.
- `yarn workspace @portfolio/service build` -> exit 0.
- `yarn workspace @search/service build` -> exit 0.
