### PR TITLE
build(deps): replace monstrs runtime packages

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1108,7 +1108,7 @@ const RAW_RUNTIME_STATE =
           ["lru-cache", "npm:7.18.3"],\
           ["negotiator", "npm:0.6.4"],\
           ["node-abort-controller", "npm:3.1.1"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"],\
+          ["node-fetch", "virtual:20d6ed2759968ba28ab6eb0ad28c424b4602e70e7c2fa9e60fe165d6ca69bc99d3f67c4be057125b902d9653e7ddba5137a47279c79a57c168e38f86a29b2d0a#npm:2.6.7"],\
           ["uuid", "npm:9.0.1"],\
           ["whatwg-mimetype", "npm:3.0.0"]\
         ],\
@@ -1764,6 +1764,67 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@atls/nestjs-gcs-client", [\
+      ["npm:0.1.2", {\
+        "packageLocation": "../.yarn/berry/cache/@atls-nestjs-gcs-client-npm-0.1.2-da360fbd20-10.zip/node_modules/@atls/nestjs-gcs-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "npm:0.1.2"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-gcs-client-virtual-fec33796b2/2/.yarn/berry/cache/@atls-nestjs-gcs-client-npm-0.1.2-da360fbd20-10.zip/node_modules/@atls/nestjs-gcs-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.2"],\
+          ["@google-cloud/storage", "npm:7.14.0"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.2", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-gcs-client-virtual-d4bb81b273/2/.yarn/berry/cache/@atls-nestjs-gcs-client-npm-0.1.2-da360fbd20-10.zip/node_modules/@atls/nestjs-gcs-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.2"],\
+          ["@google-cloud/storage", "npm:7.14.0"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@atls/nestjs-map-errors-interceptor", [\
       ["npm:0.1.36", {\
         "packageLocation": "../.yarn/berry/cache/@atls-nestjs-map-errors-interceptor-npm-0.1.36-067e65c328-10.zip/node_modules/@atls/nestjs-map-errors-interceptor/",\
@@ -1836,6 +1897,195 @@ const RAW_RUNTIME_STATE =
           "@nestjs/common",\
           "@types/nestjs__common",\
           "@types/rxjs",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@atls/nestjs-oathkeeper", [\
+      ["npm:0.1.1", {\
+        "packageLocation": "../.yarn/berry/cache/@atls-nestjs-oathkeeper-npm-0.1.1-1debd1117f-10.zip/node_modules/@atls/nestjs-oathkeeper/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-oathkeeper", "npm:0.1.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:0.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-oathkeeper-virtual-006d3f3180/2/.yarn/berry/cache/@atls-nestjs-oathkeeper-npm-0.1.1-1debd1117f-10.zip/node_modules/@atls/nestjs-oathkeeper/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-oathkeeper", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:0.1.1"],\
+          ["@nestjs/common", "virtual:a2c59bf057f2694f037ca7ada4e1bbf016f5ea3db95b16b221cd8a25df1a27bf7a9c5382e2a46202b7ad351fe71217b6176ba21df55d0bbb6d6ba4c788fd02f0#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:11.1.27"],\
+          ["@ory/oathkeeper-client-fetch", "npm:26.2.0"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#npm:0.1.1", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-oathkeeper-virtual-59d511fde9/2/.yarn/berry/cache/@atls-nestjs-oathkeeper-npm-0.1.1-1debd1117f-10.zip/node_modules/@atls/nestjs-oathkeeper/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-oathkeeper", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#npm:0.1.1"],\
+          ["@nestjs/common", "virtual:a2c59bf057f2694f037ca7ada4e1bbf016f5ea3db95b16b221cd8a25df1a27bf7a9c5382e2a46202b7ad351fe71217b6176ba21df55d0bbb6d6ba4c788fd02f0#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:eca6ac97524f1649a977b5d0cafe4f4e6ab5ac565099be149b893544f371da124d13ca90f80ef2b3f58a529f28000e35ad88bb30b348675d40ad29f022333184#npm:11.1.27"],\
+          ["@ory/oathkeeper-client-fetch", "npm:26.2.0"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@atls/nestjs-s3-client", [\
+      ["npm:0.0.5", {\
+        "packageLocation": "../.yarn/berry/cache/@atls-nestjs-s3-client-npm-0.0.5-f392b5bc2d-10.zip/node_modules/@atls/nestjs-s3-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-s3-client", "npm:0.0.5"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:35c7abb99f5ab34bfba8115c60b75cafd7390d4039788e9e8dd62e4fb20a17d4cb406fb307a3ad1f82da5cec1a7b00eaf8b966a5dc655b2369ff52695cf2b64f#npm:0.0.5", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-s3-client-virtual-3c38277e03/2/.yarn/berry/cache/@atls-nestjs-s3-client-npm-0.0.5-f392b5bc2d-10.zip/node_modules/@atls/nestjs-s3-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-s3-client", "virtual:35c7abb99f5ab34bfba8115c60b75cafd7390d4039788e9e8dd62e4fb20a17d4cb406fb307a3ad1f82da5cec1a7b00eaf8b966a5dc655b2369ff52695cf2b64f#npm:0.0.5"],\
+          ["@aws-sdk/client-s3", "npm:3.1075.0"],\
+          ["@aws-sdk/credential-providers", "npm:3.1075.0"],\
+          ["@aws-sdk/s3-request-presigner", "npm:3.1075.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:4f53d80de8c2edf6f29dd6d83d1461d2490480671cf2c881dd6178ac70610195d03e4a57b167af11ea68c078df071dfd4b28d3d152fe379b5eb29774c8f6963b#npm:0.0.5", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-s3-client-virtual-ceb14c6790/2/.yarn/berry/cache/@atls-nestjs-s3-client-npm-0.0.5-f392b5bc2d-10.zip/node_modules/@atls/nestjs-s3-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-s3-client", "virtual:4f53d80de8c2edf6f29dd6d83d1461d2490480671cf2c881dd6178ac70610195d03e4a57b167af11ea68c078df071dfd4b28d3d152fe379b5eb29774c8f6963b#npm:0.0.5"],\
+          ["@aws-sdk/client-s3", "npm:3.1075.0"],\
+          ["@aws-sdk/credential-providers", "npm:3.1075.0"],\
+          ["@aws-sdk/s3-request-presigner", "npm:3.1075.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@atls/nestjs-signed-url", [\
+      ["npm:0.6.4", {\
+        "packageLocation": "../.yarn/berry/cache/@atls-nestjs-signed-url-npm-0.6.4-dcce8314b6-10.zip/node_modules/@atls/nestjs-signed-url/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-signed-url", "npm:0.6.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.6.4", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-signed-url-virtual-4f53d80de8/2/.yarn/berry/cache/@atls-nestjs-signed-url-npm-0.6.4-dcce8314b6-10.zip/node_modules/@atls/nestjs-signed-url/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-s3-client", "virtual:4f53d80de8c2edf6f29dd6d83d1461d2490480671cf2c881dd6178ac70610195d03e4a57b167af11ea68c078df071dfd4b28d3d152fe379b5eb29774c8f6963b#npm:0.0.5"],\
+          ["@atls/nestjs-signed-url", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.6.4"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.6.4", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-signed-url-virtual-35c7abb99f/2/.yarn/berry/cache/@atls-nestjs-signed-url-npm-0.6.4-dcce8314b6-10.zip/node_modules/@atls/nestjs-signed-url/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-s3-client", "virtual:35c7abb99f5ab34bfba8115c60b75cafd7390d4039788e9e8dd62e4fb20a17d4cb406fb307a3ad1f82da5cec1a7b00eaf8b966a5dc655b2369ff52695cf2b64f#npm:0.0.5"],\
+          ["@atls/nestjs-signed-url", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.6.4"],\
+          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", null],\
+          ["rxjs", "npm:7.8.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
           "rxjs"\
         ],\
         "linkType": "HARD"\
@@ -2226,6 +2476,472 @@ const RAW_RUNTIME_STATE =
           ["@atls/webpack-proto-imports-loader", "npm:1.0.6"],\
           ["protocol-buffers-schema", "npm:3.6.0"],\
           ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/crc32", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-crc32-npm-5.2.0-a834040f6d-10.zip/node_modules/@aws-crypto/crc32/",\
+        "packageDependencies": [\
+          ["@aws-crypto/crc32", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/crc32c", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-crc32c-npm-5.2.0-e4a77c7012-10.zip/node_modules/@aws-crypto/crc32c/",\
+        "packageDependencies": [\
+          ["@aws-crypto/crc32c", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/sha1-browser", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-sha1-browser-npm-5.2.0-1973da1a70-10.zip/node_modules/@aws-crypto/sha1-browser/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha1-browser", "npm:5.2.0"],\
+          ["@aws-crypto/supports-web-crypto", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@aws-sdk/util-locate-window", "npm:3.965.8"],\
+          ["@smithy/util-utf8", "npm:2.3.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/sha256-browser", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-sha256-browser-npm-5.2.0-5e8b02b82a-10.zip/node_modules/@aws-crypto/sha256-browser/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha256-browser", "npm:5.2.0"],\
+          ["@aws-crypto/sha256-js", "npm:5.2.0"],\
+          ["@aws-crypto/supports-web-crypto", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@aws-sdk/util-locate-window", "npm:3.965.8"],\
+          ["@smithy/util-utf8", "npm:2.3.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/sha256-js", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-sha256-js-npm-5.2.0-fbe0f9fbf6-10.zip/node_modules/@aws-crypto/sha256-js/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha256-js", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/supports-web-crypto", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-supports-web-crypto-npm-5.2.0-37acf6e569-10.zip/node_modules/@aws-crypto/supports-web-crypto/",\
+        "packageDependencies": [\
+          ["@aws-crypto/supports-web-crypto", "npm:5.2.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-crypto/util", [\
+      ["npm:5.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-crypto-util-npm-5.2.0-67e90fb04c-10.zip/node_modules/@aws-crypto/util/",\
+        "packageDependencies": [\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/util-utf8", "npm:2.3.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/checksums", [\
+      ["npm:3.1000.8", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-checksums-npm-3.1000.8-23bcc05621-10.zip/node_modules/@aws-sdk/checksums/",\
+        "packageDependencies": [\
+          ["@aws-crypto/crc32", "npm:5.2.0"],\
+          ["@aws-crypto/crc32c", "npm:5.2.0"],\
+          ["@aws-crypto/util", "npm:5.2.0"],\
+          ["@aws-sdk/checksums", "npm:3.1000.8"],\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/client-cognito-identity", [\
+      ["npm:3.1075.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-client-cognito-identity-npm-3.1075.0-4994e57f25-10.zip/node_modules/@aws-sdk/client-cognito-identity/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha256-browser", "npm:5.2.0"],\
+          ["@aws-crypto/sha256-js", "npm:5.2.0"],\
+          ["@aws-sdk/client-cognito-identity", "npm:3.1075.0"],\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.972.58"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/fetch-http-handler", "npm:5.6.0"],\
+          ["@smithy/node-http-handler", "npm:4.9.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/client-s3", [\
+      ["npm:3.1075.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-client-s3-npm-3.1075.0-05130b984f-10.zip/node_modules/@aws-sdk/client-s3/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha1-browser", "npm:5.2.0"],\
+          ["@aws-crypto/sha256-browser", "npm:5.2.0"],\
+          ["@aws-crypto/sha256-js", "npm:5.2.0"],\
+          ["@aws-sdk/client-s3", "npm:3.1075.0"],\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.972.58"],\
+          ["@aws-sdk/middleware-flexible-checksums", "npm:3.974.33"],\
+          ["@aws-sdk/middleware-sdk-s3", "npm:3.972.54"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.996.35"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/fetch-http-handler", "npm:5.6.0"],\
+          ["@smithy/node-http-handler", "npm:4.9.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/core", [\
+      ["npm:3.974.23", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-core-npm-3.974.23-1285f4fdcb-10.zip/node_modules/@aws-sdk/core/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@aws-sdk/xml-builder", "npm:3.972.31"],\
+          ["@aws/lambda-invoke-store", "npm:0.2.4"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/signature-v4", "npm:5.5.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["bowser", "npm:2.14.1"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-cognito-identity", [\
+      ["npm:3.972.48", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-cognito-identity-npm-3.972.48-3a7e38cfd4-10.zip/node_modules/@aws-sdk/credential-provider-cognito-identity/",\
+        "packageDependencies": [\
+          ["@aws-sdk/credential-provider-cognito-identity", "npm:3.972.48"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-env", [\
+      ["npm:3.972.49", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-env-npm-3.972.49-0badfd7ebc-10.zip/node_modules/@aws-sdk/credential-provider-env/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-env", "npm:3.972.49"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-http", [\
+      ["npm:3.972.51", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-http-npm-3.972.51-ae2d2ff65c-10.zip/node_modules/@aws-sdk/credential-provider-http/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.972.51"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/fetch-http-handler", "npm:5.6.0"],\
+          ["@smithy/node-http-handler", "npm:4.9.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-ini", [\
+      ["npm:3.972.56", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-ini-npm-3.972.56-84e86d115d-10.zip/node_modules/@aws-sdk/credential-provider-ini/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-env", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.972.51"],\
+          ["@aws-sdk/credential-provider-ini", "npm:3.972.56"],\
+          ["@aws-sdk/credential-provider-login", "npm:3.972.55"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.972.55"],\
+          ["@aws-sdk/credential-provider-web-identity", "npm:3.972.55"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/credential-provider-imds", "npm:4.4.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-login", [\
+      ["npm:3.972.55", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-login-npm-3.972.55-38f7231311-10.zip/node_modules/@aws-sdk/credential-provider-login/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-login", "npm:3.972.55"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-node", [\
+      ["npm:3.972.58", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-node-npm-3.972.58-d21bc56b37-10.zip/node_modules/@aws-sdk/credential-provider-node/",\
+        "packageDependencies": [\
+          ["@aws-sdk/credential-provider-env", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.972.51"],\
+          ["@aws-sdk/credential-provider-ini", "npm:3.972.56"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.972.58"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.972.55"],\
+          ["@aws-sdk/credential-provider-web-identity", "npm:3.972.55"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/credential-provider-imds", "npm:4.4.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-process", [\
+      ["npm:3.972.49", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-process-npm-3.972.49-343da47049-10.zip/node_modules/@aws-sdk/credential-provider-process/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.972.49"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-sso", [\
+      ["npm:3.972.55", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-sso-npm-3.972.55-3ae6c4f0eb-10.zip/node_modules/@aws-sdk/credential-provider-sso/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.972.55"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/token-providers", "npm:3.1074.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-provider-web-identity", [\
+      ["npm:3.972.55", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-provider-web-identity-npm-3.972.55-db298ba5f2-10.zip/node_modules/@aws-sdk/credential-provider-web-identity/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-web-identity", "npm:3.972.55"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/credential-providers", [\
+      ["npm:3.1075.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-credential-providers-npm-3.1075.0-acbd999a0f-10.zip/node_modules/@aws-sdk/credential-providers/",\
+        "packageDependencies": [\
+          ["@aws-sdk/client-cognito-identity", "npm:3.1075.0"],\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/credential-provider-cognito-identity", "npm:3.972.48"],\
+          ["@aws-sdk/credential-provider-env", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-http", "npm:3.972.51"],\
+          ["@aws-sdk/credential-provider-ini", "npm:3.972.56"],\
+          ["@aws-sdk/credential-provider-login", "npm:3.972.55"],\
+          ["@aws-sdk/credential-provider-node", "npm:3.972.58"],\
+          ["@aws-sdk/credential-provider-process", "npm:3.972.49"],\
+          ["@aws-sdk/credential-provider-sso", "npm:3.972.55"],\
+          ["@aws-sdk/credential-provider-web-identity", "npm:3.972.55"],\
+          ["@aws-sdk/credential-providers", "npm:3.1075.0"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/credential-provider-imds", "npm:4.4.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/middleware-flexible-checksums", [\
+      ["npm:3.974.33", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-middleware-flexible-checksums-npm-3.974.33-4cb3a8342a-10.zip/node_modules/@aws-sdk/middleware-flexible-checksums/",\
+        "packageDependencies": [\
+          ["@aws-sdk/checksums", "npm:3.1000.8"],\
+          ["@aws-sdk/middleware-flexible-checksums", "npm:3.974.33"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/middleware-sdk-s3", [\
+      ["npm:3.972.54", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-middleware-sdk-s3-npm-3.972.54-db77599f8f-10.zip/node_modules/@aws-sdk/middleware-sdk-s3/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/middleware-sdk-s3", "npm:3.972.54"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.996.35"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/nested-clients", [\
+      ["npm:3.997.23", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-nested-clients-npm-3.997.23-889b1368e3-10.zip/node_modules/@aws-sdk/nested-clients/",\
+        "packageDependencies": [\
+          ["@aws-crypto/sha256-browser", "npm:5.2.0"],\
+          ["@aws-crypto/sha256-js", "npm:5.2.0"],\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.996.35"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/fetch-http-handler", "npm:5.6.0"],\
+          ["@smithy/node-http-handler", "npm:4.9.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/s3-request-presigner", [\
+      ["npm:3.1075.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-s3-request-presigner-npm-3.1075.0-4a9b037034-10.zip/node_modules/@aws-sdk/s3-request-presigner/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/s3-request-presigner", "npm:3.1075.0"],\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.996.35"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/signature-v4-multi-region", [\
+      ["npm:3.996.35", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-signature-v4-multi-region-npm-3.996.35-d2031b1e2e-10.zip/node_modules/@aws-sdk/signature-v4-multi-region/",\
+        "packageDependencies": [\
+          ["@aws-sdk/signature-v4-multi-region", "npm:3.996.35"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/signature-v4", "npm:5.5.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/token-providers", [\
+      ["npm:3.1074.0", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-token-providers-npm-3.1074.0-6755b20614-10.zip/node_modules/@aws-sdk/token-providers/",\
+        "packageDependencies": [\
+          ["@aws-sdk/core", "npm:3.974.23"],\
+          ["@aws-sdk/nested-clients", "npm:3.997.23"],\
+          ["@aws-sdk/token-providers", "npm:3.1074.0"],\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/types", [\
+      ["npm:3.973.13", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-types-npm-3.973.13-5943473987-10.zip/node_modules/@aws-sdk/types/",\
+        "packageDependencies": [\
+          ["@aws-sdk/types", "npm:3.973.13"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/util-locate-window", [\
+      ["npm:3.965.8", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-util-locate-window-npm-3.965.8-45e436dda6-10.zip/node_modules/@aws-sdk/util-locate-window/",\
+        "packageDependencies": [\
+          ["@aws-sdk/util-locate-window", "npm:3.965.8"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws-sdk/xml-builder", [\
+      ["npm:3.972.31", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-sdk-xml-builder-npm-3.972.31-d6c5634529-10.zip/node_modules/@aws-sdk/xml-builder/",\
+        "packageDependencies": [\
+          ["@aws-sdk/xml-builder", "npm:3.972.31"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@aws/lambda-invoke-store", [\
+      ["npm:0.2.4", {\
+        "packageLocation": "../.yarn/berry/cache/@aws-lambda-invoke-store-npm-0.2.4-505056f392-10.zip/node_modules/@aws/lambda-invoke-store/",\
+        "packageDependencies": [\
+          ["@aws/lambda-invoke-store", "npm:0.2.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -5020,12 +5736,12 @@ const RAW_RUNTIME_STATE =
       ["virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#workspace:files/application", {\
         "packageLocation": "./.yarn/__virtual__/@files-application-virtual-eefaebcc22/1/files/application/",\
         "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.2"],\
           ["@atls/nestjs-map-errors-interceptor", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:0.1.36"],\
+          ["@atls/nestjs-signed-url", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.6.4"],\
           ["@files/application", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#workspace:files/application"],\
           ["@files/domain", "workspace:files/domain"],\
           ["@files/persistence", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#workspace:files/persistence"],\
-          ["@google-cloud/storage", "npm:4.3.1"],\
-          ["@monstrs/nestjs-signed-url", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.3"],\
           ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
           ["@nestjs/core", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#npm:11.1.27"],\
           ["@nestjs/microservices", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:11.1.27"],\
@@ -5046,12 +5762,12 @@ const RAW_RUNTIME_STATE =
       ["workspace:files/application", {\
         "packageLocation": "./files/application/",\
         "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.2"],\
           ["@atls/nestjs-map-errors-interceptor", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:0.1.36"],\
+          ["@atls/nestjs-signed-url", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.6.4"],\
           ["@files/application", "workspace:files/application"],\
           ["@files/domain", "workspace:files/domain"],\
           ["@files/persistence", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#workspace:files/persistence"],\
-          ["@google-cloud/storage", "npm:4.3.1"],\
-          ["@monstrs/nestjs-signed-url", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.3"],\
           ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
           ["@nestjs/core", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
           ["@nestjs/microservices", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
@@ -5522,54 +6238,11 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["@google-cloud/common", [\
-      ["npm:2.4.0", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-common-npm-2.4.0-146ad2cf9a-10.zip/node_modules/@google-cloud/common/",\
-        "packageDependencies": [\
-          ["@google-cloud/common", "npm:2.4.0"],\
-          ["@google-cloud/projectify", "npm:1.0.4"],\
-          ["@google-cloud/promisify", "npm:1.0.4"],\
-          ["arrify", "npm:2.0.1"],\
-          ["duplexify", "npm:3.7.1"],\
-          ["ent", "npm:2.2.0"],\
-          ["extend", "npm:3.0.2"],\
-          ["google-auth-library", "npm:5.10.1"],\
-          ["retry-request", "npm:4.2.2"],\
-          ["teeny-request", "npm:6.0.3"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.10.0", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-common-npm-3.10.0-8954d20396-10.zip/node_modules/@google-cloud/common/",\
-        "packageDependencies": [\
-          ["@google-cloud/common", "npm:3.10.0"],\
-          ["@google-cloud/projectify", "npm:2.1.1"],\
-          ["@google-cloud/promisify", "npm:2.0.4"],\
-          ["arrify", "npm:2.0.1"],\
-          ["duplexify", "npm:4.1.2"],\
-          ["ent", "npm:2.2.0"],\
-          ["extend", "npm:3.0.2"],\
-          ["google-auth-library", "npm:7.14.1"],\
-          ["retry-request", "npm:4.2.2"],\
-          ["teeny-request", "npm:7.1.3"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["@google-cloud/paginator", [\
-      ["npm:2.0.3", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-paginator-npm-2.0.3-fe40ffa329-10.zip/node_modules/@google-cloud/paginator/",\
+      ["npm:5.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/@google-cloud-paginator-npm-5.0.2-7d2d8fc828-10.zip/node_modules/@google-cloud/paginator/",\
         "packageDependencies": [\
-          ["@google-cloud/paginator", "npm:2.0.3"],\
-          ["arrify", "npm:2.0.1"],\
-          ["extend", "npm:3.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.0.7", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-paginator-npm-3.0.7-b5e7c7f423-10.zip/node_modules/@google-cloud/paginator/",\
-        "packageDependencies": [\
-          ["@google-cloud/paginator", "npm:3.0.7"],\
+          ["@google-cloud/paginator", "npm:5.0.2"],\
           ["arrify", "npm:2.0.1"],\
           ["extend", "npm:3.0.2"]\
         ],\
@@ -5577,93 +6250,43 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@google-cloud/projectify", [\
-      ["npm:1.0.4", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-projectify-npm-1.0.4-f87774eea6-10.zip/node_modules/@google-cloud/projectify/",\
+      ["npm:4.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/@google-cloud-projectify-npm-4.0.0-013ddf774f-10.zip/node_modules/@google-cloud/projectify/",\
         "packageDependencies": [\
-          ["@google-cloud/projectify", "npm:1.0.4"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.1.1", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-projectify-npm-2.1.1-517268f672-10.zip/node_modules/@google-cloud/projectify/",\
-        "packageDependencies": [\
-          ["@google-cloud/projectify", "npm:2.1.1"]\
+          ["@google-cloud/projectify", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@google-cloud/promisify", [\
-      ["npm:1.0.4", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-promisify-npm-1.0.4-ddb7cd5f9a-10.zip/node_modules/@google-cloud/promisify/",\
+      ["npm:4.1.0", {\
+        "packageLocation": "../.yarn/berry/cache/@google-cloud-promisify-npm-4.1.0-39a766f491-10.zip/node_modules/@google-cloud/promisify/",\
         "packageDependencies": [\
-          ["@google-cloud/promisify", "npm:1.0.4"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.0.4", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-promisify-npm-2.0.4-0a491e630b-10.zip/node_modules/@google-cloud/promisify/",\
-        "packageDependencies": [\
-          ["@google-cloud/promisify", "npm:2.0.4"]\
+          ["@google-cloud/promisify", "npm:4.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@google-cloud/storage", [\
-      ["npm:4.3.1", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-storage-npm-4.3.1-3f7d085b2b-10.zip/node_modules/@google-cloud/storage/",\
+      ["npm:7.14.0", {\
+        "packageLocation": "../.yarn/berry/cache/@google-cloud-storage-npm-7.14.0-e340ca5284-10.zip/node_modules/@google-cloud/storage/",\
         "packageDependencies": [\
-          ["@google-cloud/common", "npm:2.4.0"],\
-          ["@google-cloud/paginator", "npm:2.0.3"],\
-          ["@google-cloud/promisify", "npm:1.0.4"],\
-          ["@google-cloud/storage", "npm:4.3.1"],\
-          ["arrify", "npm:2.0.1"],\
-          ["compressible", "npm:2.0.18"],\
-          ["concat-stream", "npm:2.0.0"],\
-          ["date-and-time", "npm:0.12.0"],\
-          ["duplexify", "npm:3.7.1"],\
-          ["extend", "npm:3.0.2"],\
-          ["gaxios", "npm:2.3.4"],\
-          ["gcs-resumable-upload", "npm:2.3.3"],\
-          ["hash-stream-validation", "npm:0.2.4"],\
-          ["mime", "npm:2.6.0"],\
-          ["mime-types", "npm:2.1.34"],\
-          ["onetime", "npm:5.1.2"],\
-          ["p-limit", "npm:2.3.0"],\
-          ["pumpify", "npm:2.0.1"],\
-          ["readable-stream", "npm:3.6.0"],\
-          ["snakeize", "npm:0.1.0"],\
-          ["stream-events", "npm:1.0.5"],\
-          ["through2", "npm:3.0.2"],\
-          ["xdg-basedir", "npm:4.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:5.18.3", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-storage-npm-5.18.3-bb1c5f4678-10.zip/node_modules/@google-cloud/storage/",\
-        "packageDependencies": [\
-          ["@google-cloud/common", "npm:3.10.0"],\
-          ["@google-cloud/paginator", "npm:3.0.7"],\
-          ["@google-cloud/promisify", "npm:2.0.4"],\
-          ["@google-cloud/storage", "npm:5.18.3"],\
+          ["@google-cloud/paginator", "npm:5.0.2"],\
+          ["@google-cloud/projectify", "npm:4.0.0"],\
+          ["@google-cloud/promisify", "npm:4.1.0"],\
+          ["@google-cloud/storage", "npm:7.14.0"],\
           ["abort-controller", "npm:3.0.0"],\
-          ["arrify", "npm:2.0.1"],\
           ["async-retry", "npm:1.3.3"],\
-          ["compressible", "npm:2.0.18"],\
-          ["configstore", "npm:5.0.1"],\
-          ["date-and-time", "npm:2.3.0"],\
-          ["duplexify", "npm:4.1.2"],\
-          ["extend", "npm:3.0.2"],\
-          ["gaxios", "npm:4.3.2"],\
-          ["get-stream", "npm:6.0.1"],\
-          ["google-auth-library", "npm:7.14.1"],\
-          ["hash-stream-validation", "npm:0.2.4"],\
+          ["duplexify", "npm:4.1.3"],\
+          ["fast-xml-parser", "npm:4.5.6"],\
+          ["gaxios", "npm:6.7.1"],\
+          ["google-auth-library", "npm:9.15.1"],\
+          ["html-entities", "npm:2.6.0"],\
           ["mime", "npm:3.0.0"],\
-          ["mime-types", "npm:2.1.34"],\
           ["p-limit", "npm:3.1.0"],\
-          ["pumpify", "npm:2.0.1"],\
-          ["snakeize", "npm:0.1.0"],\
-          ["stream-events", "npm:1.0.5"],\
-          ["xdg-basedir", "npm:4.0.0"]\
+          ["retry-request", "npm:7.0.2"],\
+          ["teeny-request", "npm:9.0.0"],\
+          ["uuid", "npm:8.3.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7858,123 +8481,6 @@ const RAW_RUNTIME_STATE =
           ["nodemailer", "npm:6.3.1"]\
         ],\
         "linkType": "SOFT"\
-      }]\
-    ]],\
-    ["@monstrs/nestjs-elasticsearch-indicator", [\
-      ["npm:0.1.1", {\
-        "packageLocation": "../.yarn/berry/cache/@monstrs-nestjs-elasticsearch-indicator-npm-0.1.1-d26347eec0-10.zip/node_modules/@monstrs/nestjs-elasticsearch-indicator/",\
-        "packageDependencies": [\
-          ["@monstrs/nestjs-elasticsearch-indicator", "npm:0.1.1"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:0.1.1", {\
-        "packageLocation": "./.yarn/__virtual__/@monstrs-nestjs-elasticsearch-indicator-virtual-34a7523fe4/2/.yarn/berry/cache/@monstrs-nestjs-elasticsearch-indicator-npm-0.1.1-d26347eec0-10.zip/node_modules/@monstrs/nestjs-elasticsearch-indicator/",\
-        "packageDependencies": [\
-          ["@godaddy/terminus", "npm:4.3.1"],\
-          ["@monstrs/nestjs-elasticsearch-indicator", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:0.1.1"],\
-          ["@nestjs/common", "virtual:27e4f2215b0812a81e5ade907acd0473127807a716500e0320147576ba85deb7cdf13795fe12a39f387997d719981de32245be12b2a65a35c56574233702e86e#npm:11.1.27"],\
-          ["@nestjs/core", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:11.1.27"],\
-          ["@nestjs/elasticsearch", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:11.1.0"],\
-          ["@nestjs/terminus", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:11.1.1"],\
-          ["@types/godaddy__terminus", null],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/nestjs__elasticsearch", null],\
-          ["@types/nestjs__terminus", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:6.5.3"]\
-        ],\
-        "packagePeers": [\
-          "@godaddy/terminus",\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@nestjs/elasticsearch",\
-          "@nestjs/terminus",\
-          "@types/godaddy__terminus",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/nestjs__elasticsearch",\
-          "@types/nestjs__terminus",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@monstrs/nestjs-signed-url", [\
-      ["npm:0.1.3", {\
-        "packageLocation": "../.yarn/berry/cache/@monstrs-nestjs-signed-url-npm-0.1.3-23479e1a10-10.zip/node_modules/@monstrs/nestjs-signed-url/",\
-        "packageDependencies": [\
-          ["@monstrs/nestjs-signed-url", "npm:0.1.3"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
-      ["virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.3", {\
-        "packageLocation": "./.yarn/__virtual__/@monstrs-nestjs-signed-url-virtual-8746a07aec/2/.yarn/berry/cache/@monstrs-nestjs-signed-url-npm-0.1.3-23479e1a10-10.zip/node_modules/@monstrs/nestjs-signed-url/",\
-        "packageDependencies": [\
-          ["@google-cloud/storage", "npm:5.18.3"],\
-          ["@monstrs/nestjs-signed-url", "virtual:eefaebcc220b32265acf5eff8b32800a4c8d3885e0843a1ae394fb9c0bd4832576da405868f2567300cd89760d618e039eb3ec34100551c947a806c96786498e#npm:0.1.3"],\
-          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
-          ["@nestjs/core", "virtual:709b5086e4e4fd3ef05942f318c289210a8226dc9a08d09be587f50c6c44a8805b5178e97fea69301038a24384c976154067d81ce2d59c49de0626c0c9c05adb#npm:11.1.27"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["reflect-metadata", null],\
-          ["rxjs", "npm:7.8.2"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.3", {\
-        "packageLocation": "./.yarn/__virtual__/@monstrs-nestjs-signed-url-virtual-6d8ab01ef0/2/.yarn/berry/cache/@monstrs-nestjs-signed-url-npm-0.1.3-23479e1a10-10.zip/node_modules/@monstrs/nestjs-signed-url/",\
-        "packageDependencies": [\
-          ["@google-cloud/storage", "npm:5.18.3"],\
-          ["@monstrs/nestjs-signed-url", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:0.1.3"],\
-          ["@nestjs/common", "virtual:e3bc9cf00542caf5a0b57444e16164324cfdc3b002153ed398bdbf7dd652ae5b10b09a2a40f2e3c1cdaf577a9a363dafdefb54d63150c95b6fc966967c0c65d1#npm:11.1.27"],\
-          ["@nestjs/core", "virtual:f9a67ca1ca045e3a9d47f4f7bac18688768f16b8f58ec891090f2db40b1c04ae5431982b316f35793f1058c15332f4ce381fac5a0770d6fbce60af3b3405f01b#npm:11.1.27"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["reflect-metadata", null],\
-          ["rxjs", "npm:7.8.2"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@monstrs/oathkeeper-auth", [\
-      ["npm:0.1.0", {\
-        "packageLocation": "../.yarn/berry/cache/@monstrs-oathkeeper-auth-npm-0.1.0-dccce861fb-10.zip/node_modules/@monstrs/oathkeeper-auth/",\
-        "packageDependencies": [\
-          ["@monstrs/oathkeeper-auth", "npm:0.1.0"],\
-          ["node-fetch", "npm:2.6.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["@nestjs/apollo", [\
@@ -15493,6 +15999,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@ory/oathkeeper-client-fetch", [\
+      ["npm:26.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@ory-oathkeeper-client-fetch-npm-26.2.0-45726637ef-10.zip/node_modules/@ory/oathkeeper-client-fetch/",\
+        "packageDependencies": [\
+          ["@ory/oathkeeper-client-fetch", "npm:26.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@phc/format", [\
       ["npm:0.5.0", {\
         "packageLocation": "../.yarn/berry/cache/@phc-format-npm-0.5.0-20418f1c17-10.zip/node_modules/@phc/format/",\
@@ -17967,9 +18482,9 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@apollo/server", "virtual:0e3d080cb17f27afbeb72ef8f8d0c6a68803f871b55732aa265d2b205a04437deb4ef15f2e06ad939125906f2159532dbde80498871f349c330d4b8ffba25915#npm:4.13.0"],\
           ["@atls/nestjs-dataloader", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:0.0.14"],\
+          ["@atls/nestjs-oathkeeper", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:0.1.1"],\
           ["@grpc/grpc-js", "npm:1.5.3"],\
           ["@grpc/proto-loader", "npm:0.5.5"],\
-          ["@monstrs/oathkeeper-auth", "npm:0.1.0"],\
           ["@nestjs/apollo", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:13.2.1"],\
           ["@nestjs/common", "virtual:a2c59bf057f2694f037ca7ada4e1bbf016f5ea3db95b16b221cd8a25df1a27bf7a9c5382e2a46202b7ad351fe71217b6176ba21df55d0bbb6d6ba4c788fd02f0#npm:11.1.27"],\
           ["@nestjs/core", "virtual:99975dd2b96e7ab0816fe11fe8d2df0e4ade3c2217b90e31fe64cc832f56f88d0f1e1bc5e10bed50663a57e97fdeb298405dfbbdabe5ef5e180c218e27313372#npm:11.1.27"],\
@@ -19152,7 +19667,6 @@ const RAW_RUNTIME_STATE =
           ["@collaboration/domain", "virtual:0643f1f56d3caf61a7c371a126e2f5af1cce49e0630df0d8051dc72672c88f7465b17570acece60905df363908cf33e738e44796d48f4a98932a7b25a72392cb#workspace:collaboration/domain"],\
           ["@elastic/elasticsearch", "npm:7.5.0"],\
           ["@godaddy/terminus", "npm:4.3.1"],\
-          ["@monstrs/nestjs-elasticsearch-indicator", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:0.1.1"],\
           ["@nestjs/common", "virtual:27e4f2215b0812a81e5ade907acd0473127807a716500e0320147576ba85deb7cdf13795fe12a39f387997d719981de32245be12b2a65a35c56574233702e86e#npm:11.1.27"],\
           ["@nestjs/core", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:11.1.27"],\
           ["@nestjs/elasticsearch", "virtual:c293e08bde02a552fc3b6a13577183e4f08c15c110cac7696443dcc705a2397fa9844a8d99a9a2835cdec7120c93a7a2766dd2e5a181d70987841a1f3ffa1cc4#npm:11.1.0"],\
@@ -20423,6 +20937,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@apollo/client", "virtual:ce40a6b8f857b17ffbf5eff75f77f3dc22ed68dad598464cdaab9fbb9e23ea5b04349cecf35161ea87a1a979bf417f32e9d39fbd5197e1ce3605c0fe20e9fa50#npm:3.5.8"],\
           ["@apollo/link-error", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#npm:2.0.0-beta.3"],\
+          ["@atls/nestjs-oathkeeper", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#npm:0.1.1"],\
           ["@atls/next-app-with-apollo", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#npm:0.2.71"],\
           ["@atls/next-app-with-helmet", "virtual:baf2beebd9150d0f5a8d531ee537d8496da8e4c81081a3e49588af74231ee8b90189240401fe95877b29ce15c5b148af99f78dd8e36dee0a42fa43da9651dacf#npm:0.2.65"],\
           ["@atls/next-app-with-provider", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:0.2.65"],\
@@ -20438,7 +20953,8 @@ const RAW_RUNTIME_STATE =
           ["@emotion/server", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:11.4.0"],\
           ["@emotion/styled", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:11.3.0"],\
           ["@formatjs/intl-relativetimeformat", "npm:4.4.3"],\
-          ["@monstrs/oathkeeper-auth", "npm:0.1.0"],\
+          ["@nestjs/common", "virtual:a2c59bf057f2694f037ca7ada4e1bbf016f5ea3db95b16b221cd8a25df1a27bf7a9c5382e2a46202b7ad351fe71217b6176ba21df55d0bbb6d6ba4c788fd02f0#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:eca6ac97524f1649a977b5d0cafe4f4e6ab5ac565099be149b893544f371da124d13ca90f80ef2b3f58a529f28000e35ad88bb30b348675d40ad29f022333184#npm:11.1.27"],\
           ["@site/index-page", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#workspace:site/pages/index-page"],\
           ["@site/projects-detail-page", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#workspace:site/pages/projects-detail-page"],\
           ["@site/projects-page", "virtual:facf602d67d3a47a69fde649069c8ea8a55ca154f018eb70d1cffe46b142bea432e2bb2de4bc47d81d2900c54aade279ddb84c097b3372f591736a2cf077aeef#workspace:site/pages/projects-page"],\
@@ -20464,6 +20980,8 @@ const RAW_RUNTIME_STATE =
           ["react-helmet", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:5.2.1"],\
           ["react-intl", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:5.18.3"],\
           ["recompose", "virtual:407796a16718a4fda8dd8ca4622ae409c5d0b34880247fbb102552a3a87ee8fed6fa2df28d452518d1557434fc1ccbb1060145502d5dffacfb5127d20bded249#npm:0.30.0"],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.2"],\
           ["typescript", "patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"],\
           ["universal-cookie", "npm:4.0.4"]\
         ],\
@@ -20814,6 +21332,108 @@ const RAW_RUNTIME_STATE =
           ["react-intl", "virtual:7d6e35b7d20f2b55747d6ac6a1c96b484ad768c0735155df92f5de6d3a40c35726cfbbc20ccf9da90455896e0680df94f9d19a3ea0a883585eb0d01a7db4f95e#npm:5.18.3"]\
         ],\
         "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@smithy/core", [\
+      ["npm:3.27.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-core-npm-3.27.0-437438e944-10.zip/node_modules/@smithy/core/",\
+        "packageDependencies": [\
+          ["@aws-crypto/crc32", "npm:5.2.0"],\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/credential-provider-imds", [\
+      ["npm:4.4.3", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-credential-provider-imds-npm-4.4.3-ec510306ed-10.zip/node_modules/@smithy/credential-provider-imds/",\
+        "packageDependencies": [\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/credential-provider-imds", "npm:4.4.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/fetch-http-handler", [\
+      ["npm:5.6.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-fetch-http-handler-npm-5.6.0-6cc2f5ca77-10.zip/node_modules/@smithy/fetch-http-handler/",\
+        "packageDependencies": [\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/fetch-http-handler", "npm:5.6.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/is-array-buffer", [\
+      ["npm:2.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-is-array-buffer-npm-2.2.0-108320772d-10.zip/node_modules/@smithy/is-array-buffer/",\
+        "packageDependencies": [\
+          ["@smithy/is-array-buffer", "npm:2.2.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/node-http-handler", [\
+      ["npm:4.9.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-node-http-handler-npm-4.9.0-092d52f6db-10.zip/node_modules/@smithy/node-http-handler/",\
+        "packageDependencies": [\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/node-http-handler", "npm:4.9.0"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/signature-v4", [\
+      ["npm:5.5.3", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-signature-v4-npm-5.5.3-cdcecb6cfe-10.zip/node_modules/@smithy/signature-v4/",\
+        "packageDependencies": [\
+          ["@smithy/core", "npm:3.27.0"],\
+          ["@smithy/signature-v4", "npm:5.5.3"],\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/types", [\
+      ["npm:4.15.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-types-npm-4.15.0-466cad627e-10.zip/node_modules/@smithy/types/",\
+        "packageDependencies": [\
+          ["@smithy/types", "npm:4.15.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/util-buffer-from", [\
+      ["npm:2.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-util-buffer-from-npm-2.2.0-0ef5989125-10.zip/node_modules/@smithy/util-buffer-from/",\
+        "packageDependencies": [\
+          ["@smithy/is-array-buffer", "npm:2.2.0"],\
+          ["@smithy/util-buffer-from", "npm:2.2.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@smithy/util-utf8", [\
+      ["npm:2.3.0", {\
+        "packageLocation": "../.yarn/berry/cache/@smithy-util-utf8-npm-2.3.0-9dcba0d35f-10.zip/node_modules/@smithy/util-utf8/",\
+        "packageDependencies": [\
+          ["@smithy/util-buffer-from", "npm:2.2.0"],\
+          ["@smithy/util-utf8", "npm:2.3.0"],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@sqltools/formatter", [\
@@ -21635,6 +22255,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@types/caseless", [\
+      ["npm:0.12.5", {\
+        "packageLocation": "../.yarn/berry/cache/@types-caseless-npm-0.12.5-d7dbdab81c-10.zip/node_modules/@types/caseless/",\
+        "packageDependencies": [\
+          ["@types/caseless", "npm:0.12.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@types/connect", [\
       ["npm:3.4.35", {\
         "packageLocation": "../.yarn/berry/cache/@types-connect-npm-3.4.35-7337eee0a3-10.zip/node_modules/@types/connect/",\
@@ -22196,6 +22825,19 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@types/request", [\
+      ["npm:2.48.13", {\
+        "packageLocation": "../.yarn/berry/cache/@types-request-npm-2.48.13-8f1b46a263-10.zip/node_modules/@types/request/",\
+        "packageDependencies": [\
+          ["@types/caseless", "npm:0.12.5"],\
+          ["@types/node", "npm:22.13.10"],\
+          ["@types/request", "npm:2.48.13"],\
+          ["@types/tough-cookie", "npm:4.0.5"],\
+          ["form-data", "npm:2.5.6"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@types/schema-utils", [\
       ["npm:2.4.0", {\
         "packageLocation": "../.yarn/berry/cache/@types-schema-utils-npm-2.4.0-9e08788987-10.zip/node_modules/@types/schema-utils/",\
@@ -22316,6 +22958,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/@types-tldjs-npm-2.3.1-5df0bfec5c-10.zip/node_modules/@types/tldjs/",\
         "packageDependencies": [\
           ["@types/tldjs", "npm:2.3.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/tough-cookie", [\
+      ["npm:4.0.5", {\
+        "packageLocation": "../.yarn/berry/cache/@types-tough-cookie-npm-4.0.5-8c5e2162e1-10.zip/node_modules/@types/tough-cookie/",\
+        "packageDependencies": [\
+          ["@types/tough-cookie", "npm:4.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -25995,6 +26646,13 @@ const RAW_RUNTIME_STATE =
           ["debug", "virtual:a74bfc561b28f961f46b2ec8ae406d012b5fbed31a317cc6e0c8e0e4bc61a668944b271114f1150bc3cadae9a39987a6be16fb9362801892abacc23919c76dd7#npm:4.3.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:7.1.4", {\
+        "packageLocation": "../.yarn/berry/cache/agent-base-npm-7.1.4-cb8b4604d5-10.zip/node_modules/agent-base/",\
+        "packageDependencies": [\
+          ["agent-base", "npm:7.1.4"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["agentkeepalive", [\
@@ -26643,7 +27301,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/apollo-server-env-npm-4.2.1-20d6ed2759-10.zip/node_modules/apollo-server-env/",\
         "packageDependencies": [\
           ["apollo-server-env", "npm:4.2.1"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"]\
+          ["node-fetch", "virtual:20d6ed2759968ba28ab6eb0ad28c424b4602e70e7c2fa9e60fe165d6ca69bc99d3f67c4be057125b902d9653e7ddba5137a47279c79a57c168e38f86a29b2d0a#npm:2.6.7"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -28755,6 +29413,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["bowser", [\
+      ["npm:2.14.1", {\
+        "packageLocation": "../.yarn/berry/cache/bowser-npm-2.14.1-41eaeb0dd6-10.zip/node_modules/bowser/",\
+        "packageDependencies": [\
+          ["bowser", "npm:2.14.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["boxen", [\
       ["npm:5.1.2", {\
         "packageLocation": "../.yarn/berry/cache/boxen-npm-5.1.2-364ee34f2f-10.zip/node_modules/boxen/",\
@@ -29646,16 +30313,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["compressible", [\
-      ["npm:2.0.18", {\
-        "packageLocation": "../.yarn/berry/cache/compressible-npm-2.0.18-ee5ab04d88-10.zip/node_modules/compressible/",\
-        "packageDependencies": [\
-          ["compressible", "npm:2.0.18"],\
-          ["mime-db", "npm:1.51.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["concat-map", [\
       ["npm:0.0.1", {\
         "packageLocation": "../.yarn/berry/cache/concat-map-npm-0.0.1-85a921b7ee-10.zip/node_modules/concat-map/",\
@@ -29685,21 +30342,6 @@ const RAW_RUNTIME_STATE =
           ["config-chain", "npm:1.1.13"],\
           ["ini", "npm:1.3.8"],\
           ["proto-list", "npm:1.2.4"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["configstore", [\
-      ["npm:5.0.1", {\
-        "packageLocation": "../.yarn/berry/cache/configstore-npm-5.0.1-739433cdc5-10.zip/node_modules/configstore/",\
-        "packageDependencies": [\
-          ["configstore", "npm:5.0.1"],\
-          ["dot-prop", "npm:5.3.0"],\
-          ["graceful-fs", "npm:4.2.6"],\
-          ["make-dir", "npm:3.1.0"],\
-          ["unique-string", "npm:2.0.0"],\
-          ["write-file-atomic", "npm:3.0.3"],\
-          ["xdg-basedir", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -30022,15 +30664,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["crypto-random-string", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/crypto-random-string-npm-2.0.0-8ab47992ef-10.zip/node_modules/crypto-random-string/",\
-        "packageDependencies": [\
-          ["crypto-random-string", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["css-animation", [\
       ["npm:1.6.1", {\
         "packageLocation": "../.yarn/berry/cache/css-animation-npm-1.6.1-f93ab10e5f-10.zip/node_modules/css-animation/",\
@@ -30205,22 +30838,6 @@ const RAW_RUNTIME_STATE =
           ["datauri", "npm:2.0.0"],\
           ["image-size", "npm:0.7.5"],\
           ["mimer", "npm:1.1.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["date-and-time", [\
-      ["npm:0.12.0", {\
-        "packageLocation": "../.yarn/berry/cache/date-and-time-npm-0.12.0-02ef4f0ba6-10.zip/node_modules/date-and-time/",\
-        "packageDependencies": [\
-          ["date-and-time", "npm:0.12.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.3.0", {\
-        "packageLocation": "../.yarn/berry/cache/date-and-time-npm-2.3.0-bbc6f79f98-10.zip/node_modules/date-and-time/",\
-        "packageDependencies": [\
-          ["date-and-time", "npm:2.3.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -30905,16 +31522,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["dot-prop", [\
-      ["npm:5.3.0", {\
-        "packageLocation": "../.yarn/berry/cache/dot-prop-npm-5.3.0-7bf6ee1eb8-10.zip/node_modules/dot-prop/",\
-        "packageDependencies": [\
-          ["dot-prop", "npm:5.3.0"],\
-          ["is-obj", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["dottie", [\
       ["npm:2.0.2", {\
         "packageLocation": "../.yarn/berry/cache/dottie-npm-2.0.2-ef16765a8f-10.zip/node_modules/dottie/",\
@@ -30965,25 +31572,14 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["duplexify", [\
-      ["npm:3.7.1", {\
-        "packageLocation": "../.yarn/berry/cache/duplexify-npm-3.7.1-8f4f1e821f-10.zip/node_modules/duplexify/",\
+      ["npm:4.1.3", {\
+        "packageLocation": "../.yarn/berry/cache/duplexify-npm-4.1.3-f0053971e9-10.zip/node_modules/duplexify/",\
         "packageDependencies": [\
-          ["duplexify", "npm:3.7.1"],\
-          ["end-of-stream", "npm:1.4.4"],\
-          ["inherits", "npm:2.0.4"],\
-          ["readable-stream", "npm:2.3.7"],\
-          ["stream-shift", "npm:1.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:4.1.2", {\
-        "packageLocation": "../.yarn/berry/cache/duplexify-npm-4.1.2-7f2140a477-10.zip/node_modules/duplexify/",\
-        "packageDependencies": [\
-          ["duplexify", "npm:4.1.2"],\
+          ["duplexify", "npm:4.1.3"],\
           ["end-of-stream", "npm:1.4.4"],\
           ["inherits", "npm:2.0.4"],\
           ["readable-stream", "npm:3.6.0"],\
-          ["stream-shift", "npm:1.0.1"]\
+          ["stream-shift", "npm:1.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -31193,15 +31789,6 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["ansi-colors", "npm:4.1.1"],\
           ["enquirer", "npm:2.3.6"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["ent", [\
-      ["npm:2.2.0", {\
-        "packageLocation": "../.yarn/berry/cache/ent-npm-2.2.0-97a5f0ffb8-10.zip/node_modules/ent/",\
-        "packageDependencies": [\
-          ["ent", "npm:2.2.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -32552,20 +33139,21 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["fast-text-encoding", [\
-      ["npm:1.0.3", {\
-        "packageLocation": "../.yarn/berry/cache/fast-text-encoding-npm-1.0.3-0f6dc8b4a3-10.zip/node_modules/fast-text-encoding/",\
-        "packageDependencies": [\
-          ["fast-text-encoding", "npm:1.0.3"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["fast-uri", [\
       ["npm:3.1.0", {\
         "packageLocation": "../.yarn/berry/cache/fast-uri-npm-3.1.0-57fa0b3f3c-10.zip/node_modules/fast-uri/",\
         "packageDependencies": [\
           ["fast-uri", "npm:3.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fast-xml-parser", [\
+      ["npm:4.5.6", {\
+        "packageLocation": "../.yarn/berry/cache/fast-xml-parser-npm-4.5.6-3bfe6f0c66-10.zip/node_modules/fast-xml-parser/",\
+        "packageDependencies": [\
+          ["fast-xml-parser", "npm:4.5.6"],\
+          ["strnum", "npm:1.1.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -32980,6 +33568,20 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["npm:2.5.6", {\
+        "packageLocation": "../.yarn/berry/cache/form-data-npm-2.5.6-9608729c99-10.zip/node_modules/form-data/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:22.13.10"],\
+          ["asynckit", "npm:0.4.0"],\
+          ["combined-stream", "npm:1.0.8"],\
+          ["es-set-tostringtag", "npm:2.1.0"],\
+          ["form-data", "npm:2.5.6"],\
+          ["hasown", "npm:2.0.4"],\
+          ["mime-types", "npm:2.1.35"],\
+          ["safe-buffer", "npm:5.2.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:3.0.1", {\
         "packageLocation": "../.yarn/berry/cache/form-data-npm-3.0.1-d080d436e0-10.zip/node_modules/form-data/",\
         "packageDependencies": [\
@@ -33269,62 +33871,27 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["gaxios", [\
-      ["npm:2.3.4", {\
-        "packageLocation": "../.yarn/berry/cache/gaxios-npm-2.3.4-ec2b90b1b2-10.zip/node_modules/gaxios/",\
+      ["npm:6.7.1", {\
+        "packageLocation": "../.yarn/berry/cache/gaxios-npm-6.7.1-11467afb7c-10.zip/node_modules/gaxios/",\
         "packageDependencies": [\
-          ["abort-controller", "npm:3.0.0"],\
           ["extend", "npm:3.0.2"],\
-          ["gaxios", "npm:2.3.4"],\
-          ["https-proxy-agent", "npm:5.0.0"],\
+          ["gaxios", "npm:6.7.1"],\
+          ["https-proxy-agent", "npm:7.0.6"],\
           ["is-stream", "npm:2.0.1"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:4.3.2", {\
-        "packageLocation": "../.yarn/berry/cache/gaxios-npm-4.3.2-b78acb4075-10.zip/node_modules/gaxios/",\
-        "packageDependencies": [\
-          ["abort-controller", "npm:3.0.0"],\
-          ["extend", "npm:3.0.2"],\
-          ["gaxios", "npm:4.3.2"],\
-          ["https-proxy-agent", "npm:5.0.0"],\
-          ["is-stream", "npm:2.0.1"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"]\
+          ["node-fetch", "virtual:11467afb7cf9e399c4ff54c4ab36fe5c4d3fece6ab1b8298fb82389f6d94b42475e1b5ec2fc3c9d191b12189c68dd36736b470173f436e08b9d4f8328c8cf29f#npm:2.7.0"],\
+          ["uuid", "npm:9.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["gcp-metadata", [\
-      ["npm:3.5.0", {\
-        "packageLocation": "../.yarn/berry/cache/gcp-metadata-npm-3.5.0-6c9d905be7-10.zip/node_modules/gcp-metadata/",\
+      ["npm:6.1.1", {\
+        "packageLocation": "../.yarn/berry/cache/gcp-metadata-npm-6.1.1-049b8b370a-10.zip/node_modules/gcp-metadata/",\
         "packageDependencies": [\
-          ["gaxios", "npm:2.3.4"],\
-          ["gcp-metadata", "npm:3.5.0"],\
-          ["json-bigint", "npm:0.3.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:4.3.1", {\
-        "packageLocation": "../.yarn/berry/cache/gcp-metadata-npm-4.3.1-2410ad0276-10.zip/node_modules/gcp-metadata/",\
-        "packageDependencies": [\
-          ["gaxios", "npm:4.3.2"],\
-          ["gcp-metadata", "npm:4.3.1"],\
+          ["gaxios", "npm:6.7.1"],\
+          ["gcp-metadata", "npm:6.1.1"],\
+          ["google-logging-utils", "npm:0.0.2"],\
           ["json-bigint", "npm:1.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["gcs-resumable-upload", [\
-      ["npm:2.3.3", {\
-        "packageLocation": "../.yarn/berry/cache/gcs-resumable-upload-npm-2.3.3-27a38e64f7-10.zip/node_modules/gcs-resumable-upload/",\
-        "packageDependencies": [\
-          ["abort-controller", "npm:3.0.0"],\
-          ["configstore", "npm:5.0.1"],\
-          ["gaxios", "npm:2.3.4"],\
-          ["gcs-resumable-upload", "npm:2.3.3"],\
-          ["google-auth-library", "npm:5.10.1"],\
-          ["pumpify", "npm:2.0.1"],\
-          ["stream-events", "npm:1.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -33742,53 +34309,25 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["google-auth-library", [\
-      ["npm:5.10.1", {\
-        "packageLocation": "../.yarn/berry/cache/google-auth-library-npm-5.10.1-900e5b0472-10.zip/node_modules/google-auth-library/",\
+      ["npm:9.15.1", {\
+        "packageLocation": "../.yarn/berry/cache/google-auth-library-npm-9.15.1-04a025e628-10.zip/node_modules/google-auth-library/",\
         "packageDependencies": [\
-          ["arrify", "npm:2.0.1"],\
           ["base64-js", "npm:1.5.1"],\
           ["ecdsa-sig-formatter", "npm:1.0.11"],\
-          ["fast-text-encoding", "npm:1.0.3"],\
-          ["gaxios", "npm:2.3.4"],\
-          ["gcp-metadata", "npm:3.5.0"],\
-          ["google-auth-library", "npm:5.10.1"],\
-          ["gtoken", "npm:4.1.4"],\
-          ["jws", "npm:4.0.0"],\
-          ["lru-cache", "npm:5.1.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.14.1", {\
-        "packageLocation": "../.yarn/berry/cache/google-auth-library-npm-7.14.1-bccc37cebe-10.zip/node_modules/google-auth-library/",\
-        "packageDependencies": [\
-          ["arrify", "npm:2.0.1"],\
-          ["base64-js", "npm:1.5.1"],\
-          ["ecdsa-sig-formatter", "npm:1.0.11"],\
-          ["fast-text-encoding", "npm:1.0.3"],\
-          ["gaxios", "npm:4.3.2"],\
-          ["gcp-metadata", "npm:4.3.1"],\
-          ["google-auth-library", "npm:7.14.1"],\
-          ["gtoken", "npm:5.3.2"],\
-          ["jws", "npm:4.0.0"],\
-          ["lru-cache", "npm:6.0.0"]\
+          ["gaxios", "npm:6.7.1"],\
+          ["gcp-metadata", "npm:6.1.1"],\
+          ["google-auth-library", "npm:9.15.1"],\
+          ["gtoken", "npm:7.1.0"],\
+          ["jws", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
-    ["google-p12-pem", [\
-      ["npm:2.0.5", {\
-        "packageLocation": "../.yarn/berry/cache/google-p12-pem-npm-2.0.5-ccc0b13905-10.zip/node_modules/google-p12-pem/",\
+    ["google-logging-utils", [\
+      ["npm:0.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/google-logging-utils-npm-0.0.2-598ff18186-10.zip/node_modules/google-logging-utils/",\
         "packageDependencies": [\
-          ["google-p12-pem", "npm:2.0.5"],\
-          ["node-forge", "npm:0.10.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.1.3", {\
-        "packageLocation": "../.yarn/berry/cache/google-p12-pem-npm-3.1.3-c844105dc3-10.zip/node_modules/google-p12-pem/",\
-        "packageDependencies": [\
-          ["google-p12-pem", "npm:3.1.3"],\
-          ["node-forge", "npm:1.3.0"]\
+          ["google-logging-utils", "npm:0.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -33915,23 +34454,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["gtoken", [\
-      ["npm:4.1.4", {\
-        "packageLocation": "../.yarn/berry/cache/gtoken-npm-4.1.4-4da1c66747-10.zip/node_modules/gtoken/",\
+      ["npm:7.1.0", {\
+        "packageLocation": "../.yarn/berry/cache/gtoken-npm-7.1.0-64216471c4-10.zip/node_modules/gtoken/",\
         "packageDependencies": [\
-          ["gaxios", "npm:2.3.4"],\
-          ["google-p12-pem", "npm:2.0.5"],\
-          ["gtoken", "npm:4.1.4"],\
-          ["jws", "npm:4.0.0"],\
-          ["mime", "npm:2.6.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:5.3.2", {\
-        "packageLocation": "../.yarn/berry/cache/gtoken-npm-5.3.2-bd1d540115-10.zip/node_modules/gtoken/",\
-        "packageDependencies": [\
-          ["gaxios", "npm:4.3.2"],\
-          ["google-p12-pem", "npm:3.1.3"],\
-          ["gtoken", "npm:5.3.2"],\
+          ["gaxios", "npm:6.7.1"],\
+          ["gtoken", "npm:7.1.0"],\
           ["jws", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -34059,15 +34586,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["hash-stream-validation", [\
-      ["npm:0.2.4", {\
-        "packageLocation": "../.yarn/berry/cache/hash-stream-validation-npm-0.2.4-2f2f18631f-10.zip/node_modules/hash-stream-validation/",\
-        "packageDependencies": [\
-          ["hash-stream-validation", "npm:0.2.4"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["hashish", [\
       ["npm:0.0.4", {\
         "packageLocation": "../.yarn/berry/cache/hashish-npm-0.0.4-e27a01a158-10.zip/node_modules/hashish/",\
@@ -34185,6 +34703,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["html-encoding-sniffer", "npm:2.0.1"],\
           ["whatwg-encoding", "npm:1.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["html-entities", [\
+      ["npm:2.6.0", {\
+        "packageLocation": "../.yarn/berry/cache/html-entities-npm-2.6.0-4dc7a46ad7-10.zip/node_modules/html-entities/",\
+        "packageDependencies": [\
+          ["html-entities", "npm:2.6.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -34355,6 +34882,15 @@ const RAW_RUNTIME_STATE =
           ["agent-base", "npm:6.0.2"],\
           ["debug", "virtual:a74bfc561b28f961f46b2ec8ae406d012b5fbed31a317cc6e0c8e0e4bc61a668944b271114f1150bc3cadae9a39987a6be16fb9362801892abacc23919c76dd7#npm:4.3.1"],\
           ["https-proxy-agent", "npm:5.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:7.0.6", {\
+        "packageLocation": "../.yarn/berry/cache/https-proxy-agent-npm-7.0.6-27a95c2690-10.zip/node_modules/https-proxy-agent/",\
+        "packageDependencies": [\
+          ["agent-base", "npm:7.1.4"],\
+          ["debug", "virtual:a74bfc561b28f961f46b2ec8ae406d012b5fbed31a317cc6e0c8e0e4bc61a668944b271114f1150bc3cadae9a39987a6be16fb9362801892abacc23919c76dd7#npm:4.3.1"],\
+          ["https-proxy-agent", "npm:7.0.6"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -35087,15 +35623,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["is-obj", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/is-obj-npm-2.0.0-3d95e053f4-10.zip/node_modules/is-obj/",\
-        "packageDependencies": [\
-          ["is-obj", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["is-plain-obj", [\
       ["npm:2.1.0", {\
         "packageLocation": "../.yarn/berry/cache/is-plain-obj-npm-2.1.0-8dffd7ae9c-10.zip/node_modules/is-plain-obj/",\
@@ -35326,7 +35853,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/isomorphic-unfetch-npm-3.1.0-001a51c96c-10.zip/node_modules/isomorphic-unfetch/",\
         "packageDependencies": [\
           ["isomorphic-unfetch", "npm:3.1.0"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"],\
+          ["node-fetch", "virtual:20d6ed2759968ba28ab6eb0ad28c424b4602e70e7c2fa9e60fe165d6ca69bc99d3f67c4be057125b902d9653e7ddba5137a47279c79a57c168e38f86a29b2d0a#npm:2.6.7"],\
           ["unfetch", "npm:4.2.0"]\
         ],\
         "linkType": "HARD"\
@@ -36143,14 +36670,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["json-bigint", [\
-      ["npm:0.3.1", {\
-        "packageLocation": "../.yarn/berry/cache/json-bigint-npm-0.3.1-08cdf6ba3a-10.zip/node_modules/json-bigint/",\
-        "packageDependencies": [\
-          ["bignumber.js", "npm:9.0.2"],\
-          ["json-bigint", "npm:0.3.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:1.0.0", {\
         "packageLocation": "../.yarn/berry/cache/json-bigint-npm-1.0.0-8e35bcb143-10.zip/node_modules/json-bigint/",\
         "packageDependencies": [\
@@ -38443,13 +38962,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:2.6.0", {\
-        "packageLocation": "../.yarn/berry/cache/node-fetch-npm-2.6.0-29c7a53447-10.zip/node_modules/node-fetch/",\
-        "packageDependencies": [\
-          ["node-fetch", "npm:2.6.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:2.6.7", {\
         "packageLocation": "../.yarn/berry/cache/node-fetch-npm-2.6.7-777aa2a6df-10.zip/node_modules/node-fetch/",\
         "packageDependencies": [\
@@ -38457,12 +38969,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7", {\
-        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-e55bcb18ce/2/.yarn/berry/cache/node-fetch-npm-2.6.7-777aa2a6df-10.zip/node_modules/node-fetch/",\
+      ["npm:2.7.0", {\
+        "packageLocation": "../.yarn/berry/cache/node-fetch-npm-2.7.0-587d57004e-10.zip/node_modules/node-fetch/",\
+        "packageDependencies": [\
+          ["node-fetch", "npm:2.7.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:11467afb7cf9e399c4ff54c4ab36fe5c4d3fece6ab1b8298fb82389f6d94b42475e1b5ec2fc3c9d191b12189c68dd36736b470173f436e08b9d4f8328c8cf29f#npm:2.7.0", {\
+        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-e9a25a80da/2/.yarn/berry/cache/node-fetch-npm-2.7.0-587d57004e-10.zip/node_modules/node-fetch/",\
         "packageDependencies": [\
           ["@types/encoding", null],\
           ["encoding", null],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"],\
+          ["node-fetch", "virtual:11467afb7cf9e399c4ff54c4ab36fe5c4d3fece6ab1b8298fb82389f6d94b42475e1b5ec2fc3c9d191b12189c68dd36736b470173f436e08b9d4f8328c8cf29f#npm:2.7.0"],\
           ["whatwg-url", "npm:5.0.0"]\
         ],\
         "packagePeers": [\
@@ -38470,20 +38989,18 @@ const RAW_RUNTIME_STATE =
           "encoding"\
         ],\
         "linkType": "HARD"\
-      }]\
-    ]],\
-    ["node-forge", [\
-      ["npm:0.10.0", {\
-        "packageLocation": "../.yarn/berry/cache/node-forge-npm-0.10.0-605ba7b28b-10.zip/node_modules/node-forge/",\
-        "packageDependencies": [\
-          ["node-forge", "npm:0.10.0"]\
-        ],\
-        "linkType": "HARD"\
       }],\
-      ["npm:1.3.0", {\
-        "packageLocation": "../.yarn/berry/cache/node-forge-npm-1.3.0-17da5aca4f-10.zip/node_modules/node-forge/",\
+      ["virtual:20d6ed2759968ba28ab6eb0ad28c424b4602e70e7c2fa9e60fe165d6ca69bc99d3f67c4be057125b902d9653e7ddba5137a47279c79a57c168e38f86a29b2d0a#npm:2.6.7", {\
+        "packageLocation": "./.yarn/__virtual__/node-fetch-virtual-cf70bab462/2/.yarn/berry/cache/node-fetch-npm-2.6.7-777aa2a6df-10.zip/node_modules/node-fetch/",\
         "packageDependencies": [\
-          ["node-forge", "npm:1.3.0"]\
+          ["@types/encoding", null],\
+          ["encoding", null],\
+          ["node-fetch", "virtual:20d6ed2759968ba28ab6eb0ad28c424b4602e70e7c2fa9e60fe165d6ca69bc99d3f67c4be057125b902d9653e7ddba5137a47279c79a57c168e38f86a29b2d0a#npm:2.6.7"],\
+          ["whatwg-url", "npm:5.0.0"]\
+        ],\
+        "packagePeers": [\
+          "@types/encoding",\
+          "encoding"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -40046,18 +40563,6 @@ const RAW_RUNTIME_STATE =
           ["end-of-stream", "npm:1.4.4"],\
           ["once", "npm:1.4.0"],\
           ["pump", "npm:3.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["pumpify", [\
-      ["npm:2.0.1", {\
-        "packageLocation": "../.yarn/berry/cache/pumpify-npm-2.0.1-159a414ebb-10.zip/node_modules/pumpify/",\
-        "packageDependencies": [\
-          ["duplexify", "npm:4.1.2"],\
-          ["inherits", "npm:2.0.4"],\
-          ["pump", "npm:3.0.0"],\
-          ["pumpify", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -41700,12 +42205,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["retry-request", [\
-      ["npm:4.2.2", {\
-        "packageLocation": "../.yarn/berry/cache/retry-request-npm-4.2.2-d96f0f10d3-10.zip/node_modules/retry-request/",\
+      ["npm:7.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/retry-request-npm-7.0.2-a41087680c-10.zip/node_modules/retry-request/",\
         "packageDependencies": [\
-          ["debug", "virtual:85d5d916b6a745b2f8de0d4b1704b7084bdd4f7573c1ef5d1c877f2c866045a9b29fe2bc752d1b73e531c378a0518dd3f9fa187b31427fb9bacbe34b14715dde#npm:4.3.3"],\
+          ["@types/request", "npm:2.48.13"],\
           ["extend", "npm:3.0.2"],\
-          ["retry-request", "npm:4.2.2"]\
+          ["retry-request", "npm:7.0.2"],\
+          ["teeny-request", "npm:9.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -42674,15 +43180,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["snakeize", [\
-      ["npm:0.1.0", {\
-        "packageLocation": "../.yarn/berry/cache/snakeize-npm-0.1.0-9e8102cc3b-10.zip/node_modules/snakeize/",\
-        "packageDependencies": [\
-          ["snakeize", "npm:0.1.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["socks", [\
       ["npm:2.6.1", {\
         "packageLocation": "../.yarn/berry/cache/socks-npm-2.6.1-09133d0d22-10.zip/node_modules/socks/",\
@@ -43006,10 +43503,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["stream-shift", [\
-      ["npm:1.0.1", {\
-        "packageLocation": "../.yarn/berry/cache/stream-shift-npm-1.0.1-9526210fa7-10.zip/node_modules/stream-shift/",\
+      ["npm:1.0.3", {\
+        "packageLocation": "../.yarn/berry/cache/stream-shift-npm-1.0.3-c1c29210c7-10.zip/node_modules/stream-shift/",\
         "packageDependencies": [\
-          ["stream-shift", "npm:1.0.1"]\
+          ["stream-shift", "npm:1.0.3"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -43308,6 +43805,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/strip-json-comments-npm-3.1.1-dcb2324823-10.zip/node_modules/strip-json-comments/",\
         "packageDependencies": [\
           ["strip-json-comments", "npm:3.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["strnum", [\
+      ["npm:1.1.2", {\
+        "packageLocation": "../.yarn/berry/cache/strnum-npm-1.1.2-67427480d6-10.zip/node_modules/strnum/",\
+        "packageDependencies": [\
+          ["strnum", "npm:1.1.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -43656,27 +44162,15 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["teeny-request", [\
-      ["npm:6.0.3", {\
-        "packageLocation": "../.yarn/berry/cache/teeny-request-npm-6.0.3-986e926ff1-10.zip/node_modules/teeny-request/",\
-        "packageDependencies": [\
-          ["http-proxy-agent", "npm:4.0.1"],\
-          ["https-proxy-agent", "npm:5.0.0"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"],\
-          ["stream-events", "npm:1.0.5"],\
-          ["teeny-request", "npm:6.0.3"],\
-          ["uuid", "npm:7.0.3"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.1.3", {\
-        "packageLocation": "../.yarn/berry/cache/teeny-request-npm-7.1.3-d7a7a2dac2-10.zip/node_modules/teeny-request/",\
+      ["npm:9.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/teeny-request-npm-9.0.0-4d571e3c55-10.zip/node_modules/teeny-request/",\
         "packageDependencies": [\
           ["http-proxy-agent", "npm:5.0.0"],\
           ["https-proxy-agent", "npm:5.0.0"],\
-          ["node-fetch", "virtual:ec2b90b1b2b8fad56d30573300be0ba53c43ad88673fdc25af69a30edeb3b0330a8245c0d2e908a87b1c0b2e91bbdf596e10f64b8fd21565332458b8d75b9cd6#npm:2.6.7"],\
+          ["node-fetch", "virtual:11467afb7cf9e399c4ff54c4ab36fe5c4d3fece6ab1b8298fb82389f6d94b42475e1b5ec2fc3c9d191b12189c68dd36736b470173f436e08b9d4f8328c8cf29f#npm:2.7.0"],\
           ["stream-events", "npm:1.0.5"],\
-          ["teeny-request", "npm:7.1.3"],\
-          ["uuid", "npm:8.3.2"]\
+          ["teeny-request", "npm:9.0.0"],\
+          ["uuid", "npm:9.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -43896,15 +44390,6 @@ const RAW_RUNTIME_STATE =
           ["readable-stream", "npm:1.0.34"],\
           ["through2", "npm:0.4.2"],\
           ["xtend", "npm:2.1.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:3.0.2", {\
-        "packageLocation": "../.yarn/berry/cache/through2-npm-3.0.2-403f837012-10.zip/node_modules/through2/",\
-        "packageDependencies": [\
-          ["inherits", "npm:2.0.4"],\
-          ["readable-stream", "npm:3.6.0"],\
-          ["through2", "npm:3.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -44723,16 +45208,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["unique-string", [\
-      ["npm:2.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/unique-string-npm-2.0.0-3153c97e47-10.zip/node_modules/unique-string/",\
-        "packageDependencies": [\
-          ["crypto-random-string", "npm:2.0.0"],\
-          ["unique-string", "npm:2.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["universal-cookie", [\
       ["npm:4.0.4", {\
         "packageLocation": "../.yarn/berry/cache/universal-cookie-npm-4.0.4-aa9b4bcfbf-10.zip/node_modules/universal-cookie/",\
@@ -44968,13 +45443,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/uuid-npm-3.4.0-4fd8ef88ad-10.zip/node_modules/uuid/",\
         "packageDependencies": [\
           ["uuid", "npm:3.4.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:7.0.3", {\
-        "packageLocation": "../.yarn/berry/cache/uuid-npm-7.0.3-2b088bd924-10.zip/node_modules/uuid/",\
-        "packageDependencies": [\
-          ["uuid", "npm:7.0.3"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -45643,15 +46111,6 @@ const RAW_RUNTIME_STATE =
           "@types/utf-8-validate",\
           "bufferutil",\
           "utf-8-validate"\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["xdg-basedir", [\
-      ["npm:4.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/xdg-basedir-npm-4.0.0-ed08d380e2-10.zip/node_modules/xdg-basedir/",\
-        "packageDependencies": [\
-          ["xdg-basedir", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -120,9 +120,6 @@ packageExtensions:
   '@monstrs/nestjs-dataloader@*':
     dependencies:
       '@nestjs/core': '*'
-  '@monstrs/nestjs-signed-url@*':
-    dependencies:
-      '@google-cloud/storage': '*'
   '@nestjs/common@8':
     dependencies:
       '@types/node': '*'

--- a/files/application/package.json
+++ b/files/application/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
+    "@atls/nestjs-gcs-client": "0.1.2",
+    "@atls/nestjs-signed-url": "0.6.4",
     "@files/domain": "workspace:0.0.2",
     "@files/persistence": "workspace:0.0.2",
-    "@monstrs/nestjs-signed-url": "0.1.3",
     "@nestjs/common": "11.1.27",
     "@nestjs/typeorm": "11.0.2",
     "class-validator": "0.15.1",
@@ -16,7 +17,6 @@
   },
   "devDependencies": {
     "@atls/nestjs-map-errors-interceptor": "^0.1.36",
-    "@google-cloud/storage": "4.3.1",
     "@nestjs/core": "11.1.27",
     "@nestjs/microservices": "11.1.27",
     "@nestjs/testing": "11.1.27",

--- a/files/application/src/module.ts
+++ b/files/application/src/module.ts
@@ -1,11 +1,24 @@
-import { SignedUrlModule }    from '@monstrs/nestjs-signed-url'
+import { GcsClientFactory }   from '@atls/nestjs-gcs-client'
+import { GcsClientModule }    from '@atls/nestjs-gcs-client'
+import { SignedUrlModule }    from '@atls/nestjs-signed-url'
 import { Module }             from '@nestjs/common'
 
 import { FileQueriesService } from './services/index.js'
 import { UploadService }      from './services/index.js'
 
 @Module({
-  imports: [SignedUrlModule.gcs()],
+  imports: [
+    SignedUrlModule.gcsAsync<[GcsClientFactory]>({
+      imports: [
+        GcsClientModule.register({
+          apiEndpoint: process.env.GCS_API_ENDPOINT,
+          keyFilename: process.env.GCS_KEY_FILENAME,
+        }),
+      ],
+      inject: [GcsClientFactory],
+      useFactory: (factory: GcsClientFactory) => factory.create(),
+    }),
+  ],
   providers: [FileQueriesService, UploadService],
   exports: [FileQueriesService, UploadService],
 })

--- a/files/application/src/services/UploadService.ts
+++ b/files/application/src/services/UploadService.ts
@@ -1,4 +1,4 @@
-import { SignedUrlService }       from '@monstrs/nestjs-signed-url'
+import { SignedUrlSigner }        from '@atls/nestjs-signed-url'
 import { Injectable }             from '@nestjs/common'
 import { extname }                from 'path'
 import { format }                 from 'path'
@@ -15,7 +15,7 @@ export class UploadService {
   constructor(
     private readonly uploadRepository: UploadEntityRepository,
     private readonly fileRepository: FileEntityRepository,
-    private readonly signedUrlService: SignedUrlService
+    private readonly signedUrlSigner: SignedUrlSigner
   ) {}
 
   async create(command: CreateUploadCommand): Promise<any> {
@@ -24,9 +24,13 @@ export class UploadService {
       ext: extname(command.name),
     })
 
-    const { url, fields } = await this.signedUrlService.generateWriteUrl(filename, {
-      type: command.type,
-    })
+    const { url, fields } = await this.signedUrlSigner.generateWriteUrl(
+      process.env.GCS_BUCKET,
+      filename,
+      {
+        contentType: command.type,
+      }
+    )
 
     const upload = Upload.create(command.id, command.type, command.name, url, fields)
 

--- a/public-gateway/app/package.json
+++ b/public-gateway/app/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "@apollo/server": "4.13.0",
     "@atls/nestjs-dataloader": "0.0.14",
+    "@atls/nestjs-oathkeeper": "0.1.1",
     "@grpc/grpc-js": "^1.5.3",
     "@grpc/proto-loader": "0.5.5",
-    "@monstrs/oathkeeper-auth": "0.1.0",
     "@nestjs/apollo": "13.2.1",
     "@nestjs/common": "11.1.27",
     "@nestjs/core": "11.1.27",

--- a/public-gateway/app/src/index.ts
+++ b/public-gateway/app/src/index.ts
@@ -1,9 +1,8 @@
-import { oathkeeperAuth }     from '@monstrs/oathkeeper-auth'
+import { OathkeeperIdentityMiddleware } from '@atls/nestjs-oathkeeper'
+import { NestFactory }                  from '@nestjs/core'
 
-import { NestFactory }        from '@nestjs/core'
-
-import { ActivityMiddleware } from './middleware/index.js'
-import { ApplicationModule }  from './module.js'
+import { ActivityMiddleware }           from './middleware/index.js'
+import { ApplicationModule }            from './module.js'
 
 declare const module: any
 
@@ -71,16 +70,25 @@ const resolveUserFromKratos = async (req: any, _res: any, next: () => void) => {
   next()
 }
 
+const useOptionalOathkeeperAuth = (middleware: OathkeeperIdentityMiddleware) =>
+  async (req: any, res: any, next: () => void) => {
+    if (getHeader(req, 'authorization')) {
+      next()
+      return
+    }
+
+    try {
+      await middleware.use(req, res, next)
+    } catch (error) {
+      next()
+    }
+  }
+
 const bootstrap = async () => {
   const app = await NestFactory.create(ApplicationModule)
 
   if (process.env.NODE_ENV !== 'production') {
-    app.use(
-      oathkeeperAuth(
-        process.env.OATHKEEPER_DECISIONS_URL || 'http://serenity-oathkeeper-api:4456/decisions',
-        { host: 'serenity.aunited.dev' }
-      )
-    )
+    app.use(useOptionalOathkeeperAuth(app.get(OathkeeperIdentityMiddleware)))
   }
 
   app.use(resolveUserFromKratos)

--- a/public-gateway/app/src/index.ts
+++ b/public-gateway/app/src/index.ts
@@ -72,11 +72,6 @@ const resolveUserFromKratos = async (req: any, _res: any, next: () => void) => {
 
 const useOptionalOathkeeperAuth = (middleware: OathkeeperIdentityMiddleware) =>
   async (req: any, res: any, next: () => void) => {
-    if (getHeader(req, 'authorization')) {
-      next()
-      return
-    }
-
     try {
       await middleware.use(req, res, next)
     } catch (error) {

--- a/public-gateway/app/src/module.ts
+++ b/public-gateway/app/src/module.ts
@@ -1,11 +1,12 @@
-import { Module }                from '@nestjs/common'
-import { join }                  from 'path'
-
 import { DataLoaderInterceptor } from '@atls/nestjs-dataloader'
+import { OathkeeperModule }      from '@atls/nestjs-oathkeeper'
 import { ApolloDriver }          from '@nestjs/apollo'
 import { ApolloDriverConfig }    from '@nestjs/apollo'
+import { Module }                from '@nestjs/common'
 import { APP_INTERCEPTOR }       from '@nestjs/core'
 import { GraphQLModule }         from '@nestjs/graphql'
+import { join }                  from 'path'
+
 import { CatalogModule }         from '@public-gateway/catalog'
 import { CollaborationModule }   from '@public-gateway/collaboration'
 import { FilesModule }           from '@public-gateway/files'
@@ -14,6 +15,11 @@ import { PortfolioModule }       from '@public-gateway/portfolio'
 import { SearchModule }          from '@public-gateway/search'
 
 import { ActivityMiddleware }    from './middleware/index.js'
+
+const oathkeeperApiUrl =
+  process.env.OATHKEEPER_API_URL ||
+  process.env.OATHKEEPER_DECISIONS_URL?.replace(/\/decisions\/?$/, '') ||
+  'http://serenity-oathkeeper-api:4456'
 
 // eslint-disable-next-line
 const playground =
@@ -27,6 +33,17 @@ const playground =
 
 @Module({
   imports: [
+    OathkeeperModule.register({
+      urls: {
+        api: oathkeeperApiUrl,
+      },
+      decision: {
+        forwardedHost: 'serenity.aunited.dev',
+      },
+      middleware: {
+        mode: 'enrich',
+      },
+    }),
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       introspection: true,

--- a/search/service/package.json
+++ b/search/service/package.json
@@ -14,7 +14,6 @@
     "@collaboration/domain": "0.0.1",
     "@elastic/elasticsearch": "7.5.0",
     "@godaddy/terminus": "4.3.1",
-    "@monstrs/nestjs-elasticsearch-indicator": "0.1.1",
     "@nestjs/common": "11.1.27",
     "@nestjs/core": "11.1.27",
     "@nestjs/elasticsearch": "11.1.0",

--- a/site/entrypoints/renderer/package.json
+++ b/site/entrypoints/renderer/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@apollo/link-error": "^2.0.0-beta.3",
+    "@atls/nestjs-oathkeeper": "0.1.1",
     "@atls/next-app-with-apollo": "^0.2.67",
     "@atls/next-config-with-extract-intl-messages": "^0.0.1",
     "@atls/next-config-with-pnp-workspaces": "^0.0.1",
@@ -19,7 +20,8 @@
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@formatjs/intl-relativetimeformat": "4.4.3",
-    "@monstrs/oathkeeper-auth": "0.1.0",
+    "@nestjs/common": "11.1.27",
+    "@nestjs/core": "11.1.27",
     "@site/specialists-detail-page": "0.0.1",
     "events": "^3.3.0",
     "express": "^4.17.1",
@@ -27,7 +29,9 @@
     "next": "16.2.9",
     "next-compose-plugins": "^2.2.0",
     "next-fonts": "0.19.0",
-    "next-images": "1.2.0"
+    "next-images": "1.2.0",
+    "reflect-metadata": "0.2.2",
+    "rxjs": "7.8.2"
   },
   "devDependencies": {
     "@apollo/client": "3.5.8",

--- a/site/entrypoints/renderer/src/index.ts
+++ b/site/entrypoints/renderer/src/index.ts
@@ -13,20 +13,6 @@ const oathkeeperApiUrl =
   process.env.OATHKEEPER_DECISIONS_URL?.replace(/\/decisions\/?$/, '') ||
   'http://serenity-oathkeeper-api:4456'
 
-const getHeader = (req: Request, name: string): string | undefined => {
-  if (typeof req.get === 'function') {
-    return req.get(name)
-  }
-
-  const value = req.headers?.[name.toLowerCase()]
-
-  if (Array.isArray(value)) {
-    return value[0]
-  }
-
-  return value
-}
-
 const createOathkeeperDecisionClient = (apiUrl: string) => ({
   async decide(headers: OathkeeperHeaders) {
     const response = await fetch(new URL('/decisions', apiUrl).toString(), {
@@ -60,11 +46,6 @@ const createOathkeeperAuth = (forwardedHost: string) => {
   )
 
   return async (req: Request, _res: Response, next: () => void) => {
-    if (getHeader(req, 'authorization')) {
-      next()
-      return
-    }
-
     try {
       const decision = await decisions.decide({
         headers: req.headers,

--- a/site/entrypoints/renderer/src/index.ts
+++ b/site/entrypoints/renderer/src/index.ts
@@ -1,12 +1,99 @@
-import { oathkeeperAuth } from '@monstrs/oathkeeper-auth'
-import express            from 'express'
-import next               from 'next'
-import path               from 'path'
+import type { OathkeeperHeaders }       from '@atls/nestjs-oathkeeper'
+import type { OathkeeperModuleOptions } from '@atls/nestjs-oathkeeper'
+import type { Request }                 from 'express'
+import type { Response }                from 'express'
+
+import { OathkeeperDecisionService }    from '@atls/nestjs-oathkeeper'
+import express                          from 'express'
+import next                             from 'next'
+import path                             from 'path'
+
+const oathkeeperApiUrl =
+  process.env.OATHKEEPER_API_URL ||
+  process.env.OATHKEEPER_DECISIONS_URL?.replace(/\/decisions\/?$/, '') ||
+  'http://serenity-oathkeeper-api:4456'
+
+const getHeader = (req: Request, name: string): string | undefined => {
+  if (typeof req.get === 'function') {
+    return req.get(name)
+  }
+
+  const value = req.headers?.[name.toLowerCase()]
+
+  if (Array.isArray(value)) {
+    return value[0]
+  }
+
+  return value
+}
+
+const createOathkeeperDecisionClient = (apiUrl: string) => ({
+  async decide(headers: OathkeeperHeaders) {
+    const response = await fetch(new URL('/decisions', apiUrl).toString(), {
+      headers,
+      method: 'GET',
+    })
+
+    return {
+      headers: response.headers,
+      status: response.status,
+    }
+  },
+})
+
+const createOathkeeperAuth = (forwardedHost: string) => {
+  const options: OathkeeperModuleOptions = {
+    decision: {
+      forwardedHost,
+    },
+    middleware: {
+      mode: 'enrich',
+    },
+    urls: {
+      api: oathkeeperApiUrl,
+    },
+  }
+
+  const decisions = new OathkeeperDecisionService(
+    createOathkeeperDecisionClient(oathkeeperApiUrl),
+    options
+  )
+
+  return async (req: Request, _res: Response, next: () => void) => {
+    if (getHeader(req, 'authorization')) {
+      next()
+      return
+    }
+
+    try {
+      const decision = await decisions.decide({
+        headers: req.headers,
+        host: forwardedHost,
+        method: req.method || 'GET',
+        proto: req.protocol,
+        uri: req.url || '/',
+      })
+
+      if (decision.allowed) {
+        if (decision.authorization) {
+          req.headers.authorization = decision.authorization
+        }
+
+        if (decision.user) {
+          req.headers['x-user'] = decision.user
+        }
+      }
+    } catch (error) {}
+
+    next()
+  }
+}
 
 const bootstrap = async () => {
   const app = next({
     dev: process.env.NODE_ENV !== 'production',
-    dir: process.env.NODE_ENV !== 'production' ? path.join(__dirname, '../src/index.js') : __dirname,
+    dir:
+      process.env.NODE_ENV !== 'production' ? path.join(__dirname, '../src/index.js') : __dirname,
   })
 
   const handle = app.getRequestHandler()
@@ -16,12 +103,7 @@ const bootstrap = async () => {
   const server = express()
 
   if (process.env.NODE_ENV !== 'production') {
-    server.use(
-      oathkeeperAuth(
-        process.env.OATHKEEPER_DECISIONS_URL || 'http://serenity-oathkeeper-api:4456/decisions',
-        { host: 'serenity.atls.tech' }
-      )
-    )
+    server.use(createOathkeeperAuth('serenity.atls.tech'))
   }
 
   server.get('*', (req, res) => handle(req, res))

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@atls/nestjs-gcs-client@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@atls/nestjs-gcs-client@npm:0.1.2"
+  dependencies:
+    "@google-cloud/storage": "npm:7.14.0"
+  peerDependencies:
+    "@nestjs/common": 11
+    "@nestjs/core": 11
+    reflect-metadata: ^0.2
+    rxjs: ^7
+  checksum: 10/128333970d3054b02e945a12bf3cbde488b17f91c1dcdff991d61e9e08dea506ed20263041d7df750713e70b71d6463edd282b434707eda1573d212dda8e9931
+  languageName: node
+  linkType: hard
+
 "@atls/nestjs-map-errors-interceptor@npm:^0.1.36":
   version: 0.1.36
   resolution: "@atls/nestjs-map-errors-interceptor@npm:0.1.36"
@@ -494,6 +508,51 @@ __metadata:
     "@nestjs/common": ^8.0.4
     rxjs: ^7.2.0
   checksum: 10/0708d86cf14895619d921bfe8c20b5945133e5692c4dc7573e7c7164bbc458f9035dc3efd1c73d65c0de57e76f8d737165faa6859b429652c835c83d4226bcb2
+  languageName: node
+  linkType: hard
+
+"@atls/nestjs-oathkeeper@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@atls/nestjs-oathkeeper@npm:0.1.1"
+  dependencies:
+    "@ory/oathkeeper-client-fetch": "npm:26.2.0"
+  peerDependencies:
+    "@nestjs/common": 11
+    "@nestjs/core": 11
+    reflect-metadata: 0.2
+    rxjs: 7
+  checksum: 10/2084f927472e9fe10f59c9a181ba5be0d2d33cfbf4a0fcaa50b5a6407ef3a33417b45042c3c4216393fa4a3fdd5cf78e53e49acfecfe0a9c3758e9818e5154ec
+  languageName: node
+  linkType: hard
+
+"@atls/nestjs-s3-client@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@atls/nestjs-s3-client@npm:0.0.5"
+  dependencies:
+    "@aws-sdk/client-s3": "npm:^3.363.0"
+    "@aws-sdk/credential-providers": "npm:^3.363.0"
+    "@aws-sdk/s3-request-presigner": "npm:^3.363.0"
+    "@aws-sdk/types": "npm:^3.357.0"
+  peerDependencies:
+    "@nestjs/common": 11
+    "@nestjs/core": 11
+    reflect-metadata: ^0.2
+    rxjs: ^7
+  checksum: 10/63c0521bf76515fa6ada5fa3fcf37f6dccaa9cf95529764b05b5952d299100c92af70e9f48247615baca3081927871686844d93c9827d3a2c1f1a3eacc73f9c7
+  languageName: node
+  linkType: hard
+
+"@atls/nestjs-signed-url@npm:0.6.4":
+  version: 0.6.4
+  resolution: "@atls/nestjs-signed-url@npm:0.6.4"
+  dependencies:
+    "@atls/nestjs-s3-client": "npm:0.0.5"
+  peerDependencies:
+    "@nestjs/common": 11
+    "@nestjs/core": 11
+    reflect-metadata: 0.2
+    rxjs: 7
+  checksum: 10/f2a2b725ccc5abca113048cec1b2d73ba385c0b2506cda2cbaa8ef61d8beea1e65a3edf97e279c5ddbb5ce9225ea22764d977dfc2ead13eb740887cbc4807084
   languageName: node
   linkType: hard
 
@@ -655,6 +714,440 @@ __metadata:
     protocol-buffers-schema: "npm:3.6.0"
     tslib: "npm:2.8.1"
   checksum: 10/506b173664ed7fc924229fdca6f50f32f4406623c5a853ec95273ef6bf8a1a702329176c4eb9cac959ea3a1353536200f64a50549cf4d63428b8822863344f35
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/crc32@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/1b0a56ad4cb44c9512d8b1668dcf9306ab541d3a73829f435ca97abaec8d56f3db953db03ad0d0698754fea16fcd803d11fa42e0889bc7b803c6a030b04c63de
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/crc32c@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/08bd1db17d7c772fa6e34b38a360ce77ad041164743113eefa8343c2af917a419697daf090c5854129ef19f3a9673ed1fd8446e03eb32c8ed52d2cc409b0dee7
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha1-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/239f4c59cce9abd33c01117b10553fbef868a063e74faf17edb798c250d759a2578841efa2837e5e51854f52ef57dbc40780b073cae20f89ebed6a8cc7fa06f1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/sha256-js": "npm:^5.2.0"
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/2b1b701ca6caa876333b4eb2b96e5187d71ebb51ebf8e2d632690dbcdedeff038202d23adcc97e023437ed42bb1963b7b463e343687edf0635fd4b98b2edad1a
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:5.2.0, @aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f46aace7b873c615be4e787ab0efd0148ef7de48f9f12c7d043e05c52e52b75bb0bf6dbcb9b2852d940d7724fab7b6d5ff1469160a3dd024efe7a68b5f70df8c
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:5.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/6ed0c7e17f4f6663d057630805c45edb35d5693380c24ab52d4c453ece303c6c8a6ade9ee93c97dda77d9f6cae376ffbb44467057161c513dffa3422250edaf5
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:5.2.0, @aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f80a174c404e1ad4364741c942f440e75f834c08278fa754349fe23a6edc679d480ea9ced5820774aee58091ed270067022d8059ecf1a7ef452d58134ac7e9e1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/checksums@npm:^3.1000.8":
+  version: 3.1000.8
+  resolution: "@aws-sdk/checksums@npm:3.1000.8"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@aws-crypto/crc32c": "npm:5.2.0"
+    "@aws-crypto/util": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0cd340f0238759df537e7e1579420cbcfa6be366412dc87596118c402ad8801cfacb0c57397aad856e3fee50466a6e217aa610b0a2b1e0aa278642ca04bd7da2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-cognito-identity@npm:3.1075.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/28c25b396540a378f65b0dadfb5cd37a24c4b831c5e94754706a04c8b98aee8c7bfd4ce1420e8a6af84d7224f289c94b259bfb0a97bb5abbd0a97c073866f7b6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.363.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/client-s3@npm:3.1075.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/middleware-flexible-checksums": "npm:^3.974.33"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.54"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7482774e4341a922b436931ffa3f0b002e6dbbce153d671a84f056459eba113d9ac01e1973238a525a17437d08f457502f07799795e1530c0e636c7b71205c17
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.974.23":
+  version: 3.974.23
+  resolution: "@aws-sdk/core@npm:3.974.23"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@aws-sdk/xml-builder": "npm:^3.972.31"
+    "@aws/lambda-invoke-store": "npm:^0.2.2"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/signature-v4": "npm:^5.4.6"
+    "@smithy/types": "npm:^4.14.3"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f1de7689020cd1f90706183511fc09e53801f4bc92ab62d98781d96b16634fe98c180e2f3a3c74da195f9e1cfb75ef689f01576e3449946b0186a04bd6c23b33
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-cognito-identity@npm:^3.972.48":
+  version: 3.972.48
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.972.48"
+  dependencies:
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/04537ef70f0b7bd295e777c41c55ba91179cf87177eb29dd7c7af1fbf3b063e7e2f99b68fb9f4f264e95db779b98644cf40f0eca7dcfd40e21eec3d883b9e49a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.49":
+  version: 3.972.49
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.49"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c00ea76c8715a10a97e5c259a4a0c38500d7eca779bbec3de65361b09d74080f95df40c63aba5e4929248516e772e8c77cc1ca8690cd704a0c7294f812523a62
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.51":
+  version: 3.972.51
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.51"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/6b8bfcfcc192a6ccd3fa8e0f445e2f4aee434b8c9a12114f620331bf5284593404de5bf8d4efb9b7d47b539f5440a206a53cc6292f7ebcdec34bc712bbb0c6a4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.972.56":
+  version: 3.972.56
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.56"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.51"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.55"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.55"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.55"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/credential-provider-imds": "npm:^4.3.7"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/35a1567b14d543260e0191e3a1f4128c2102174a57616863c9beb985f82c3acb4c1000dad040a7391849e30923913feebddb7c92df44f17cfb90f193b1f5822d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.55":
+  version: 3.972.55
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.55"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3c1138968bcb9d842039e927ca025edb29b4a8a229d5761c7dd6ae3c9a074b8a116ec005de606251c4b910f5c374441341b513cf521f16684330c73ea931ca4a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.58":
+  version: 3.972.58
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.58"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.51"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.56"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.55"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.55"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/credential-provider-imds": "npm:^4.3.7"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/43e05640cf30ed78d9db15ba91600ec3d59a60d386947866d37f239defe63c407c16dffd1b19c4ec168b9983a7b3dc63b8d94d2a300f69b8aaff0946e7b6560b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.49":
+  version: 3.972.49
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.49"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/ae87f6ee1c228a8f509c8a9dfdad8cf2a2dcfc07f83ee8dfd56712d26f56ac8e663309595abac347d6cb72f08c04fbcbcfff67bc787f05d6c3ce0a4e6ff1720e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.972.55":
+  version: 3.972.55
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.55"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/token-providers": "npm:3.1074.0"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0efe629ae6fea7dd0308a368a106ca71eaa530d4213cc9731240a876cf5938d6f6a51f0e7f05619e22daddde7974b359b5e3409230f9f2024a166a309b26d12e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.55":
+  version: 3.972.55
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.55"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/bdcbbd444b162ef28f58975f342cc23d644089ae6d8e6e676b52f4980e63ccd84433c192f2ab8088a49403e99f6042f04c424f9448b82b2f799339e51633d24a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-providers@npm:^3.363.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/credential-providers@npm:3.1075.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": "npm:3.1075.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/credential-provider-cognito-identity": "npm:^3.972.48"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.51"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.56"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.55"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.58"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.49"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.55"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.55"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/credential-provider-imds": "npm:^4.3.7"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/a98f5151963eb4fd4af5b28841444b93c7e32bc51369015419a45d4a9476c6dce03ff60252a3349af6eab86e81952ef767299a40c65923bf3e645af5c46a307f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:^3.974.33":
+  version: 3.974.33
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.974.33"
+  dependencies:
+    "@aws-sdk/checksums": "npm:^3.1000.8"
+    tslib: "npm:^2.6.2"
+  checksum: 10/67f25172de08299665e52360d54eb0ef5537602b0f92e67eca429b5ed52e1ae6d022d89d927343dc8f4ef2277e27d35d1c4e68f1687e0c7652d00a84bf3efc08
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.54":
+  version: 3.972.54
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.54"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/0908270870c5bc19151447914a018b21a2c449a7454bbd6cda3ee333cdde3aed3622d94336043c7c0dacef343ea1ebe4b3ab297e36249cd834e9c5f21f966f48
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.23":
+  version: 3.997.23
+  resolution: "@aws-sdk/nested-clients@npm:3.997.23"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/fetch-http-handler": "npm:^5.4.6"
+    "@smithy/node-http-handler": "npm:^4.7.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/32c7370f41702b0c3f178b219214c981910f0fa7d614e1d33f173584cadad0ff6e77444381a1b2772009abe2b9337c222425a0731f3fa6f9e9752941dfcb21be
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/s3-request-presigner@npm:^3.363.0":
+  version: 3.1075.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.1075.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.35"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/78f65d657f352863c575d6bd749819a3b6833bcb09d887b69240b88481aa3a0f841dd7880a83c6630b1dcdf1549b9336f1b5c48ac8c15362dad6ca1b8cd3728f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.35":
+  version: 3.996.35
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.35"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/signature-v4": "npm:^5.4.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/80b01e4283cbfc460b586a897415f0835bdf9850dc2f4c1d669ecf23ba423f72b33c01b0036a4183b8e3f6b51ec4b5a1d8ff2e68ceacbd3308164143463b7cc4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1074.0":
+  version: 3.1074.0
+  resolution: "@aws-sdk/token-providers@npm:3.1074.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.23"
+    "@aws-sdk/nested-clients": "npm:^3.997.23"
+    "@aws-sdk/types": "npm:^3.973.13"
+    "@smithy/core": "npm:^3.24.6"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/f782d47a7388830f588c914bdc8339606679b82ec9974c4ea6842daaf121661bb39b35a7991c8a9495572953061fa71c0907299dea74df6197ea6ac8967ebd49
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.357.0, @aws-sdk/types@npm:^3.973.13":
+  version: 3.973.13
+  resolution: "@aws-sdk/types@npm:3.973.13"
+  dependencies:
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c8bce83bc28daa5138b0a5f4bccd650f8e1ff98a07ac93acc59b2c4297bd20c59db5a09d3a66551cbdf4cb1082650b08c2ab06f789d76e7642dcb7d0e2e757f6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.965.8
+  resolution: "@aws-sdk/util-locate-window@npm:3.965.8"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/2244bb447b2c85eb764f8d7d283726a6c25e96999a349d0939cf8da44f6aee1f60c71b71d5aee11831c91706b4b8f00eee6613688124fbf752218fb5f36e9d4f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.31":
+  version: 3.972.31
+  resolution: "@aws-sdk/xml-builder@npm:3.972.31"
+  dependencies:
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10/7812d1b3bcb576b75f97ee30c37501bb9a5eb8f61adf41d8e131a105158e3553cb175f1da4cbacb347c6536f5570370ed307a2c9b12e44c9b32178ff269dac99
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "@aws/lambda-invoke-store@npm:0.2.4"
+  checksum: 10/47e73cf73141be73854c69722502e928a435b3d908ffa693a9545c1099dd7b2dd3f67c43c523d786a75911100e77ed52dce1f88d09363a67526448c5b7c804d5
   languageName: node
   linkType: hard
 
@@ -2503,11 +2996,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@files/application@workspace:files/application"
   dependencies:
+    "@atls/nestjs-gcs-client": "npm:0.1.2"
     "@atls/nestjs-map-errors-interceptor": "npm:^0.1.36"
+    "@atls/nestjs-signed-url": "npm:0.6.4"
     "@files/domain": "workspace:0.0.2"
     "@files/persistence": "workspace:0.0.2"
-    "@google-cloud/storage": "npm:4.3.1"
-    "@monstrs/nestjs-signed-url": "npm:0.1.3"
     "@nestjs/common": "npm:11.1.27"
     "@nestjs/core": "npm:11.1.27"
     "@nestjs/microservices": "npm:11.1.27"
@@ -2868,145 +3361,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/common@npm:^2.1.1":
-  version: 2.4.0
-  resolution: "@google-cloud/common@npm:2.4.0"
-  dependencies:
-    "@google-cloud/projectify": "npm:^1.0.0"
-    "@google-cloud/promisify": "npm:^1.0.0"
-    arrify: "npm:^2.0.0"
-    duplexify: "npm:^3.6.0"
-    ent: "npm:^2.2.0"
-    extend: "npm:^3.0.2"
-    google-auth-library: "npm:^5.5.0"
-    retry-request: "npm:^4.0.0"
-    teeny-request: "npm:^6.0.0"
-  checksum: 10/216d777c56c2e62ec7f57c525a5d276465aff173063fe5a8732e3554663892c45234545a25fd236a57d8622b9e79ac4c39a2134dd646461b9377bc6ad737bab5
-  languageName: node
-  linkType: hard
-
-"@google-cloud/common@npm:^3.8.1":
-  version: 3.10.0
-  resolution: "@google-cloud/common@npm:3.10.0"
-  dependencies:
-    "@google-cloud/projectify": "npm:^2.0.0"
-    "@google-cloud/promisify": "npm:^2.0.0"
-    arrify: "npm:^2.0.1"
-    duplexify: "npm:^4.1.1"
-    ent: "npm:^2.2.0"
-    extend: "npm:^3.0.2"
-    google-auth-library: "npm:^7.14.0"
-    retry-request: "npm:^4.2.2"
-    teeny-request: "npm:^7.0.0"
-  checksum: 10/48616886d715e3012df74534db055c04a49b3d1553326e47ce4e3f28c4ce9415501fd8b66c32da1e3feb395e2b4b7f698946fda4219588edc92c2b6765669fcd
-  languageName: node
-  linkType: hard
-
-"@google-cloud/paginator@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "@google-cloud/paginator@npm:2.0.3"
+"@google-cloud/paginator@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "@google-cloud/paginator@npm:5.0.2"
   dependencies:
     arrify: "npm:^2.0.0"
     extend: "npm:^3.0.2"
-  checksum: 10/039c6bd406e33f4f3800d92d5004ff0989c9b4c392c3e80af34bbd5039019c953cc4e2ea6c000142ee3448e3f2daba95c644beedd1b79f2ab5c8a54cb33bdae0
+  checksum: 10/b64ba2029b77fdcf3c827aea0b6d128122fd1d2f4aa8c1ba70747cba0659d4216a283769fb3bbeb8f726176f5282624637f02c30f118a010e05838411da0cb76
   languageName: node
   linkType: hard
 
-"@google-cloud/paginator@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@google-cloud/paginator@npm:3.0.7"
+"@google-cloud/projectify@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@google-cloud/projectify@npm:4.0.0"
+  checksum: 10/fdccdda0b50855c35541d71c46a6603f3302ff1a00108d946272cb2167435da00e2a2da5963fe489f4f5a4a9eb6320abeb97d3269974a972ae89f5df8451922d
+  languageName: node
+  linkType: hard
+
+"@google-cloud/promisify@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "@google-cloud/promisify@npm:4.1.0"
+  checksum: 10/b933047c197e248c50428b17b5ac7ca8f711eb112a2e7a10af231ac00d1ff1d20325788556b07bc270a2406d165a198fd9ad1d114d7f11214e861b02077aaa0c
+  languageName: node
+  linkType: hard
+
+"@google-cloud/storage@npm:7.14.0":
+  version: 7.14.0
+  resolution: "@google-cloud/storage@npm:7.14.0"
   dependencies:
-    arrify: "npm:^2.0.0"
-    extend: "npm:^3.0.2"
-  checksum: 10/b4d61df447d1bb35515cb4335f35a42b7ded9157ccc814ebc5753366ab091c1baced8b1067d876a3e2eb336ca628b6c4f25effe62cd84c7130f24388d711e485
-  languageName: node
-  linkType: hard
-
-"@google-cloud/projectify@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "@google-cloud/projectify@npm:1.0.4"
-  checksum: 10/6e8541194b4a2b6bf4001cfb83d0f95b0629eb711882a25dcbf8b03bff5335bbb58399fdfb026adc02e14bf3764fcb70c52e54bec97ef4a416889f63634e25d4
-  languageName: node
-  linkType: hard
-
-"@google-cloud/projectify@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@google-cloud/projectify@npm:2.1.1"
-  checksum: 10/86a615a637238bb23f35dfb2320b65977786064813ec825a9b56ec0b8bf7a69197f823f9b14545a6d71e91294232b4ad482e9f5f9cdc012015d681dd1328ed5f
-  languageName: node
-  linkType: hard
-
-"@google-cloud/promisify@npm:^1.0.0":
-  version: 1.0.4
-  resolution: "@google-cloud/promisify@npm:1.0.4"
-  checksum: 10/0725168267727feb133108979374f5681b0f86c2d74f40701477053938f474c18c7f2cd30bc1f4eb822102ba724907ba33b1258564f40a022f88b02013116827
-  languageName: node
-  linkType: hard
-
-"@google-cloud/promisify@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "@google-cloud/promisify@npm:2.0.4"
-  checksum: 10/26f82454008023c728cb32964af0681c6b29615ec4a297ec4588b8a84a78698b9e540928a25ef516ba518368c1e578c8e4222c0ce7769c638add9f58a002c25d
-  languageName: node
-  linkType: hard
-
-"@google-cloud/storage@npm:*":
-  version: 5.18.3
-  resolution: "@google-cloud/storage@npm:5.18.3"
-  dependencies:
-    "@google-cloud/common": "npm:^3.8.1"
-    "@google-cloud/paginator": "npm:^3.0.7"
-    "@google-cloud/promisify": "npm:^2.0.0"
+    "@google-cloud/paginator": "npm:^5.0.0"
+    "@google-cloud/projectify": "npm:^4.0.0"
+    "@google-cloud/promisify": "npm:^4.0.0"
     abort-controller: "npm:^3.0.0"
-    arrify: "npm:^2.0.0"
     async-retry: "npm:^1.3.3"
-    compressible: "npm:^2.0.12"
-    configstore: "npm:^5.0.0"
-    date-and-time: "npm:^2.0.0"
-    duplexify: "npm:^4.0.0"
-    extend: "npm:^3.0.2"
-    gaxios: "npm:^4.0.0"
-    get-stream: "npm:^6.0.0"
-    google-auth-library: "npm:^7.0.0"
-    hash-stream-validation: "npm:^0.2.2"
+    duplexify: "npm:^4.1.3"
+    fast-xml-parser: "npm:^4.4.1"
+    gaxios: "npm:^6.0.2"
+    google-auth-library: "npm:^9.6.3"
+    html-entities: "npm:^2.5.2"
     mime: "npm:^3.0.0"
-    mime-types: "npm:^2.0.8"
     p-limit: "npm:^3.0.1"
-    pumpify: "npm:^2.0.0"
-    snakeize: "npm:^0.1.0"
-    stream-events: "npm:^1.0.4"
-    xdg-basedir: "npm:^4.0.0"
-  checksum: 10/bd3ec45b32ff996bfeb86659b943da328d520b375d4c0ea857467cafd6369207cf022d6693da382beaf043d7f51dda3da6d82f89eccc59a8f2af0d83d7134311
-  languageName: node
-  linkType: hard
-
-"@google-cloud/storage@npm:4.3.1":
-  version: 4.3.1
-  resolution: "@google-cloud/storage@npm:4.3.1"
-  dependencies:
-    "@google-cloud/common": "npm:^2.1.1"
-    "@google-cloud/paginator": "npm:^2.0.0"
-    "@google-cloud/promisify": "npm:^1.0.0"
-    arrify: "npm:^2.0.0"
-    compressible: "npm:^2.0.12"
-    concat-stream: "npm:^2.0.0"
-    date-and-time: "npm:^0.12.0"
-    duplexify: "npm:^3.5.0"
-    extend: "npm:^3.0.2"
-    gaxios: "npm:^2.0.1"
-    gcs-resumable-upload: "npm:^2.2.4"
-    hash-stream-validation: "npm:^0.2.2"
-    mime: "npm:^2.2.0"
-    mime-types: "npm:^2.0.8"
-    onetime: "npm:^5.1.0"
-    p-limit: "npm:^2.2.0"
-    pumpify: "npm:^2.0.0"
-    readable-stream: "npm:^3.4.0"
-    snakeize: "npm:^0.1.0"
-    stream-events: "npm:^1.0.1"
-    through2: "npm:^3.0.0"
-    xdg-basedir: "npm:^4.0.0"
-  checksum: 10/cd975ac31cae91e49c41f58f90eae42a6d7dbadb4a25c59678bc5c4f340d5b661346e6a8c1a0e3f10fc9b2e0f8256c7a0c705ae87bd7e6e13feebc47693dd9dd
+    retry-request: "npm:^7.0.0"
+    teeny-request: "npm:^9.0.0"
+    uuid: "npm:^8.0.0"
+  checksum: 10/0726fde2697da696637fab91ebd756354a58c1331f6a0b9ecc5011de4aae72cd9e1fe3e9564aee15c6a2118e45ed0ae8c3ac9685c6581db6107080f906a949e9
   languageName: node
   linkType: hard
 
@@ -4395,42 +4793,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@monstrs/nestjs-elasticsearch-indicator@npm:0.1.1":
-  version: 0.1.1
-  resolution: "@monstrs/nestjs-elasticsearch-indicator@npm:0.1.1"
-  peerDependencies:
-    "@godaddy/terminus": ^4.2.1
-    "@nestjs/common": ^6.0.2
-    "@nestjs/core": ^6.0.2
-    "@nestjs/elasticsearch": ^7.0.0
-    "@nestjs/terminus": ^6.0.2
-    reflect-metadata: ^0.1.12
-    rxjs: ^6.3.3
-  checksum: 10/e2b62e027d8ccae094b9df735c0bc70333f6e82e1a33185373a363a2f11481596243cc70dc320b4eb8f6e1b032474930aa162d3d2505c7729c1942f6be19dc3e
-  languageName: node
-  linkType: hard
-
-"@monstrs/nestjs-signed-url@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@monstrs/nestjs-signed-url@npm:0.1.3"
-  peerDependencies:
-    "@nestjs/common": ^6.0.2
-    "@nestjs/core": ^6.0.2
-    reflect-metadata: ^0.1.12
-    rxjs: ^6.3.3
-  checksum: 10/07e1dec2f68f1a96607e2d1bf135637b1fdcea922bfd60569b3d1ad186de7bf1d8aba91a4c71c93454293dc8ee011b734e1696b7c810bb0e48b22961e92299c0
-  languageName: node
-  linkType: hard
-
-"@monstrs/oathkeeper-auth@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@monstrs/oathkeeper-auth@npm:0.1.0"
-  dependencies:
-    node-fetch: "npm:2.6.0"
-  checksum: 10/2d0f9b5807951ad8f17a4dffeb7c9ac97968c96293f39507f34f73560f184674166a909055b8a6a3a6bb54096f7574efffd42fbe42dcd6e91e90c9a20f2b9c82
-  languageName: node
-  linkType: hard
-
 "@nestjs/apollo@npm:13.2.1":
   version: 13.2.1
   resolution: "@nestjs/apollo@npm:13.2.1"
@@ -4941,6 +5303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ory/oathkeeper-client-fetch@npm:26.2.0":
+  version: 26.2.0
+  resolution: "@ory/oathkeeper-client-fetch@npm:26.2.0"
+  checksum: 10/105e47993b769d95885ef38891f8b50894f21c92949cd795cee29d376f01d4730c2226382f1b485edd94a8c04581690426e9e0c38296b1678177d9530757b3fd
+  languageName: node
+  linkType: hard
+
 "@phc/format@npm:^0.5.0":
   version: 0.5.0
   resolution: "@phc/format@npm:0.5.0"
@@ -5303,9 +5672,9 @@ __metadata:
   dependencies:
     "@apollo/server": "npm:4.13.0"
     "@atls/nestjs-dataloader": "npm:0.0.14"
+    "@atls/nestjs-oathkeeper": "npm:0.1.1"
     "@grpc/grpc-js": "npm:^1.5.3"
     "@grpc/proto-loader": "npm:0.5.5"
-    "@monstrs/oathkeeper-auth": "npm:0.1.0"
     "@nestjs/apollo": "npm:13.2.1"
     "@nestjs/common": "npm:11.1.27"
     "@nestjs/core": "npm:11.1.27"
@@ -5544,7 +5913,6 @@ __metadata:
     "@collaboration/domain": "npm:0.0.1"
     "@elastic/elasticsearch": "npm:7.5.0"
     "@godaddy/terminus": "npm:4.3.1"
-    "@monstrs/nestjs-elasticsearch-indicator": "npm:0.1.1"
     "@nestjs/common": "npm:11.1.27"
     "@nestjs/core": "npm:11.1.27"
     "@nestjs/elasticsearch": "npm:11.1.0"
@@ -5937,6 +6305,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.5.8"
     "@apollo/link-error": "npm:^2.0.0-beta.3"
+    "@atls/nestjs-oathkeeper": "npm:0.1.1"
     "@atls/next-app-with-apollo": "npm:^0.2.67"
     "@atls/next-app-with-helmet": "npm:^0.2.63"
     "@atls/next-app-with-provider": "npm:^0.2.63"
@@ -5952,7 +6321,8 @@ __metadata:
     "@emotion/server": "npm:^11.4.0"
     "@emotion/styled": "npm:^11.3.0"
     "@formatjs/intl-relativetimeformat": "npm:4.4.3"
-    "@monstrs/oathkeeper-auth": "npm:0.1.0"
+    "@nestjs/common": "npm:11.1.27"
+    "@nestjs/core": "npm:11.1.27"
     "@site/index-page": "npm:0.0.1"
     "@site/projects-detail-page": "npm:0.0.1"
     "@site/projects-page": "npm:0.0.1"
@@ -5977,6 +6347,8 @@ __metadata:
     react-helmet: "npm:5.2.1"
     react-intl: "npm:5.3.2"
     recompose: "npm:0.30.0"
+    reflect-metadata: "npm:0.2.2"
+    rxjs: "npm:7.8.2"
     typescript: "npm:5.5.4"
     universal-cookie: "npm:^4.0.4"
   languageName: unknown
@@ -6100,6 +6472,99 @@ __metadata:
     react-intl: "*"
   languageName: unknown
   linkType: soft
+
+"@smithy/core@npm:^3.24.6, @smithy/core@npm:^3.27.0":
+  version: 3.27.0
+  resolution: "@smithy/core@npm:3.27.0"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@smithy/types": "npm:^4.15.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d376e1e450cc51b8249ebf8049bdc047f535f94e8f399e69f53e947051d6f84386702b69dcf66cc6c4633fcd136ba9bda40721478f3d4d1298d4ead49529a98b
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.3.7":
+  version: 4.4.3
+  resolution: "@smithy/credential-provider-imds@npm:4.4.3"
+  dependencies:
+    "@smithy/core": "npm:^3.27.0"
+    "@smithy/types": "npm:^4.15.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/9f240370254a12c8b06231cea75c66873065c80affa13a4ae8f88aed69159036814cba06e692be56fca4de91fdd84c10043ef19e8e24a3772f0f01801858def4
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.4.6":
+  version: 5.6.0
+  resolution: "@smithy/fetch-http-handler@npm:5.6.0"
+  dependencies:
+    "@smithy/core": "npm:^3.27.0"
+    "@smithy/types": "npm:^4.15.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d26c15fc5db698d83c43359d29d7b3eabf6c11a3b7dde7e5360dd0537963f9ba3110cd686a30b8cd6afe0ea4661a417a50dd353574cfd76534746f7dc1539190
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/d366743ecc7a9fc3bad21dbb3950d213c12bdd4aeb62b1265bf6cbe38309df547664ef3e51ab732e704485194f15e89d361943b0bfbe3fe1a4b3178b942913cc
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.7.6":
+  version: 4.9.0
+  resolution: "@smithy/node-http-handler@npm:4.9.0"
+  dependencies:
+    "@smithy/core": "npm:^3.27.0"
+    "@smithy/types": "npm:^4.15.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/3567e53823b14dc20d06d684d244f33e548a7d4722c26fdfca8d7f9e86580201232a62acf1084ea2eeb56c9f4d250c2c7b28bd70619e8524664b8b60b6684b1e
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.4.6":
+  version: 5.5.3
+  resolution: "@smithy/signature-v4@npm:5.5.3"
+  dependencies:
+    "@smithy/core": "npm:^3.27.0"
+    "@smithy/types": "npm:^4.15.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/df88d75485e3cbb80dc18766c592797417540559b7cc0dc5416828f9ef26ef9f4398b43073e1d345fecd0ebe09352ca070fe78ceb78bed3c94152df82460984e
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.14.3, @smithy/types@npm:^4.15.0":
+  version: 4.15.0
+  resolution: "@smithy/types@npm:4.15.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10/e41a84ec3eb9feb45040ccd541b1cacf0fc2375297802886459cb9311ff361080978c08ef98e9ad69f41d80ad212279d682a8fe30a993381b2f1dd376c1006c3
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/53253e4e351df3c4b7907dca48a0a6ceae783e98a8e73526820b122b3047a53fd127c19f4d8301f68d852011d821da519da783de57e0b22eed57c4df5b90d089
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/c766ead8dac6bc6169f4cac1cc47ef7bd86928d06255148f9528228002f669c8cc49f78dc2b9ba5d7e214d40315024a9e32c5c9130b33e20f0fe4532acd0dff5
+  languageName: node
+  linkType: hard
 
 "@sqltools/formatter@npm:^1.2.5":
   version: 1.2.5
@@ -6714,6 +7179,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/caseless@npm:*":
+  version: 0.12.5
+  resolution: "@types/caseless@npm:0.12.5"
+  checksum: 10/f6a3628add76d27005495914c9c3873a93536957edaa5b69c63b46fe10b4649a6fecf16b676c1695f46aab851da47ec6047dcf3570fa8d9b6883492ff6d074e0
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:*":
   version: 3.4.35
   resolution: "@types/connect@npm:3.4.35"
@@ -7187,6 +7659,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/request@npm:^2.48.8":
+  version: 2.48.13
+  resolution: "@types/request@npm:2.48.13"
+  dependencies:
+    "@types/caseless": "npm:*"
+    "@types/node": "npm:*"
+    "@types/tough-cookie": "npm:*"
+    form-data: "npm:^2.5.5"
+  checksum: 10/174abc42adfc0c45f6a675095b72be344e907afd74fcfe33dea4fbd7489d54bc5aae781e5064436a8079ea74458a1fdefeb62c5260a19a08c7b536529fac61c1
+  languageName: node
+  linkType: hard
+
 "@types/schema-utils@npm:^2.4.0":
   version: 2.4.0
   resolution: "@types/schema-utils@npm:2.4.0"
@@ -7303,6 +7787,13 @@ __metadata:
   version: 2.3.1
   resolution: "@types/tldjs@npm:2.3.1"
   checksum: 10/3b796de8c41c2f108cc5e8cc888d4676964fe73bdbb9383ab7e0e6a69bdd845d0b186d0688bdbe751ba8ffb1694dd5c12c0785c4959b0ecdbcd031dfcc36887d
+  languageName: node
+  linkType: hard
+
+"@types/tough-cookie@npm:*":
+  version: 4.0.5
+  resolution: "@types/tough-cookie@npm:4.0.5"
+  checksum: 10/01fd82efc8202670865928629697b62fe9bf0c0dcbc5b1c115831caeb073a2c0abb871ff393d7df1ae94ea41e256cb87d2a5a91fd03cdb1b0b4384e08d4ee482
   languageName: node
   linkType: hard
 
@@ -8553,6 +9044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:^7.1.2":
+  version: 7.1.4
+  resolution: "agent-base@npm:7.1.4"
+  checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
+  languageName: node
+  linkType: hard
+
 "agentkeepalive@npm:^4.1.3":
   version: 4.1.4
   resolution: "agentkeepalive@npm:4.1.4"
@@ -9255,7 +9753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arrify@npm:^2.0.0, arrify@npm:^2.0.1":
+"arrify@npm:^2.0.0":
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 10/067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
@@ -10761,6 +11259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10/a002f0795ef360314c75552b94daa42f74473f38b34255cfa959779e875806ef8e41b24ec63a533717798c8ef70bb991aef3037a2bb5dd32e8f507b39a509163
+  languageName: node
+  linkType: hard
+
 "boxen@npm:5.1.2":
   version: 5.1.2
   resolution: "boxen@npm:5.1.2"
@@ -11585,15 +12090,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compressible@npm:^2.0.12":
-  version: 2.0.18
-  resolution: "compressible@npm:2.0.18"
-  dependencies:
-    mime-db: "npm:>= 1.43.0 < 2"
-  checksum: 10/58321a85b375d39230405654721353f709d0c1442129e9a17081771b816302a012471a9b8f4864c7dbe02eef7f2aaac3c614795197092262e94b409c9be108f0
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -11620,20 +12116,6 @@ __metadata:
     ini: "npm:^1.3.4"
     proto-list: "npm:~1.2.1"
   checksum: 10/83d22cabf709e7669f6870021c4d552e4fc02e9682702b726be94295f42ce76cfed00f70b2910ce3d6c9465d9758e191e28ad2e72ff4e3331768a90da6c1ef03
-  languageName: node
-  linkType: hard
-
-"configstore@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "configstore@npm:5.0.1"
-  dependencies:
-    dot-prop: "npm:^5.2.0"
-    graceful-fs: "npm:^4.1.2"
-    make-dir: "npm:^3.0.0"
-    unique-string: "npm:^2.0.0"
-    write-file-atomic: "npm:^3.0.0"
-    xdg-basedir: "npm:^4.0.0"
-  checksum: 10/60ef65d493b63f96e14b11ba7ec072fdbf3d40110a94fb7199d1c287761bdea5c5244e76b2596325f30c1b652213aa75de96ea20afd4a5f82065e61ea090988e
   languageName: node
   linkType: hard
 
@@ -11927,13 +12409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-random-string@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "crypto-random-string@npm:2.0.0"
-  checksum: 10/0283879f55e7c16fdceacc181f87a0a65c53bc16ffe1d58b9d19a6277adcd71900d02bb2c4843dd55e78c51e30e89b0fec618a7f170ebcc95b33182c28f05fd6
-  languageName: node
-  linkType: hard
-
 "css-animation@npm:^1.3.2":
   version: 1.6.1
   resolution: "css-animation@npm:1.6.1"
@@ -12088,20 +12563,6 @@ __metadata:
     image-size: "npm:^0.7.3"
     mimer: "npm:^1.0.0"
   checksum: 10/872ed2f8de36bb1d8072425e9b4ef2f640b08a37dafdee5f47493b036b5fad7ea0064565d4e309759c235ccb12c16e82a8b01bc508a2be9c32d4b5177cc138fa
-  languageName: node
-  linkType: hard
-
-"date-and-time@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "date-and-time@npm:0.12.0"
-  checksum: 10/4cf227ed2810ac42910ddb79ef114f22426cbe764075922a1d8dd5da0d7d47536cc47aa77099ba80c0761587b3415b920aebca531a39d6c9a657149fa69f6e5c
-  languageName: node
-  linkType: hard
-
-"date-and-time@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "date-and-time@npm:2.3.0"
-  checksum: 10/cebfbf9f071de04d97b43994f5dc8727950e21dc1eff5675f0cafade7fa05bf667cde858d1a5169efde21452160a57eb7cd433e0c372f1010c34513ceec5ba59
   languageName: node
   linkType: hard
 
@@ -12669,15 +13130,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "dot-prop@npm:5.3.0"
-  dependencies:
-    is-obj: "npm:^2.0.0"
-  checksum: 10/33b2561617bd5c73cf9305368ba4638871c5dbf9c8100c8335acd2e2d590a81ec0e75c11cfaea5cc3cf8c2f668cad4beddb52c11856d0c9e666348eee1baf57a
-  languageName: node
-  linkType: hard
-
 "dottie@npm:^2.0.2":
   version: 2.0.2
   resolution: "dottie@npm:2.0.2"
@@ -12719,27 +13171,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^3.5.0, duplexify@npm:^3.6.0":
-  version: 3.7.1
-  resolution: "duplexify@npm:3.7.1"
-  dependencies:
-    end-of-stream: "npm:^1.0.0"
-    inherits: "npm:^2.0.1"
-    readable-stream: "npm:^2.0.0"
-    stream-shift: "npm:^1.0.0"
-  checksum: 10/7799984d178fb57e11c43f5f172a10f795322ec85ff664c2a98d2c2de6deeb9d7a30b810f83923dcd7ebe0f1786724b8aee2b62ca4577522141f93d6d48fb31c
-  languageName: node
-  linkType: hard
-
-"duplexify@npm:^4.0.0, duplexify@npm:^4.1.1":
-  version: 4.1.2
-  resolution: "duplexify@npm:4.1.2"
+"duplexify@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "duplexify@npm:4.1.3"
   dependencies:
     end-of-stream: "npm:^1.4.1"
     inherits: "npm:^2.0.3"
     readable-stream: "npm:^3.1.1"
-    stream-shift: "npm:^1.0.0"
-  checksum: 10/eeb4f362defa4da0b2474d853bc4edfa446faeb1bde76819a68035632c118de91f6a58e6fe05c84f6e6de2548f8323ec8473aa9fe37332c99e4d77539747193e
+    stream-shift: "npm:^1.0.2"
+  checksum: 10/b44b98ba0ffac3a658b4b1bf877219e996db288c5ae6f3dc55ca9b2cbef7df60c10eabfdd947f3d73a623eb9975a74a66d6d61e6f26bff90155315adb362aa77
   languageName: node
   linkType: hard
 
@@ -12892,7 +13332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -12927,13 +13367,6 @@ __metadata:
   dependencies:
     ansi-colors: "npm:^4.1.1"
   checksum: 10/751d14f037eb7683997e696fb8d5fe2675e0b0cde91182c128cf598acf3f5bd9005f35f7c2a9109e291140af496ebec237b6dac86067d59a9b44f3688107f426
-  languageName: node
-  linkType: hard
-
-"ent@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "ent@npm:2.2.0"
-  checksum: 10/818a2b5f5039ea02c9e232ba4c7496ced8512341b2524ae7c6c808d2e2b357d8087e715e0e3950cec9895c20c9b3443e0b56a2e26879984d97bb511c5fbb5299
   languageName: node
   linkType: hard
 
@@ -14076,17 +14509,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-text-encoding@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "fast-text-encoding@npm:1.0.3"
-  checksum: 10/152411caaf560381f58af03da1757f8aab747890f67c5d0cbd60acc24581ffe382f5c8a1f8d4524b25bd9391a7cb14e10fc981695d646e9b6d51d3e56aa82704
-  languageName: node
-  linkType: hard
-
 "fast-uri@npm:^3.0.1":
   version: 3.1.0
   resolution: "fast-uri@npm:3.1.0"
   checksum: 10/818b2c96dc913bcf8511d844c3d2420e2c70b325c0653633f51821e4e29013c2015387944435cd0ef5322c36c9beecc31e44f71b257aeb8e0b333c1d62bb17c2
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^4.4.1":
+  version: 4.5.6
+  resolution: "fast-xml-parser@npm:4.5.6"
+  dependencies:
+    strnum: "npm:^1.0.5"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10/dd77cce4b1b322400339147b72b2d315bddc12c6ed3ca82bfc87543ced6dd8d81a6e0b429489e2f048f39258aa2023580654c8934881c633b9d58a6e79672349
   languageName: node
   linkType: hard
 
@@ -14420,6 +14857,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^2.5.5":
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/7b2afddf638125b6d22936a1f642e88887b279504510e3f56be6dc90bea35cb8124fe6ecc75032e92264b5ebfbd183d0992307588c782eaa88d1bed76381ad6b
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^3.0.0":
   version: 3.0.1
   resolution: "form-data@npm:3.0.1"
@@ -14683,65 +15134,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gaxios@npm:^2.0.0, gaxios@npm:^2.0.1, gaxios@npm:^2.1.0":
-  version: 2.3.4
-  resolution: "gaxios@npm:2.3.4"
+"gaxios@npm:^6.0.0, gaxios@npm:^6.0.2, gaxios@npm:^6.1.1":
+  version: 6.7.1
+  resolution: "gaxios@npm:6.7.1"
   dependencies:
-    abort-controller: "npm:^3.0.0"
     extend: "npm:^3.0.2"
-    https-proxy-agent: "npm:^5.0.0"
+    https-proxy-agent: "npm:^7.0.1"
     is-stream: "npm:^2.0.0"
-    node-fetch: "npm:^2.3.0"
-  checksum: 10/9f42a63054a0ab894b3aff54f36559a97b693c7b6cb4a66ec46a81b001082ae96c62c2d984bd16fd58237e91d648edf8285a7a7e48c5cd1aa81f2e85b093637a
+    node-fetch: "npm:^2.6.9"
+    uuid: "npm:^9.0.1"
+  checksum: 10/c85599162208884eadee91215ebbfa1faa412551df4044626cb561300e15193726e8f23d63b486533e066dadad130f58ed872a23acab455238d8d48b531a0695
   languageName: node
   linkType: hard
 
-"gaxios@npm:^4.0.0":
-  version: 4.3.2
-  resolution: "gaxios@npm:4.3.2"
+"gcp-metadata@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "gcp-metadata@npm:6.1.1"
   dependencies:
-    abort-controller: "npm:^3.0.0"
-    extend: "npm:^3.0.2"
-    https-proxy-agent: "npm:^5.0.0"
-    is-stream: "npm:^2.0.0"
-    node-fetch: "npm:^2.6.1"
-  checksum: 10/4e5a5a4bc52788284a3db341a9740e41ab1bdda4fda9f53975af78519e92d93ae99717282fbfcd47f38559f0f5d5e70f391baca6c594534da7f88e34150fc7b0
-  languageName: node
-  linkType: hard
-
-"gcp-metadata@npm:^3.4.0":
-  version: 3.5.0
-  resolution: "gcp-metadata@npm:3.5.0"
-  dependencies:
-    gaxios: "npm:^2.1.0"
-    json-bigint: "npm:^0.3.0"
-  checksum: 10/6530a2dea677e847c2bcc816f5d1db060ece00e584c29e53b96122c9f8051c9d90479a89306a35d9290fff8cdbf2e0985a68a7fc553111e5c83965b03d74ab19
-  languageName: node
-  linkType: hard
-
-"gcp-metadata@npm:^4.2.0":
-  version: 4.3.1
-  resolution: "gcp-metadata@npm:4.3.1"
-  dependencies:
-    gaxios: "npm:^4.0.0"
+    gaxios: "npm:^6.1.1"
+    google-logging-utils: "npm:^0.0.2"
     json-bigint: "npm:^1.0.0"
-  checksum: 10/fe343dd34e23acea4cb84776238da1fd1e6a1dece237eedfd720fc40ab69136af778a749a73c13a3c40177eee462ce4c7e2770ab95c951f13fcaa93a2fed15d5
-  languageName: node
-  linkType: hard
-
-"gcs-resumable-upload@npm:^2.2.4":
-  version: 2.3.3
-  resolution: "gcs-resumable-upload@npm:2.3.3"
-  dependencies:
-    abort-controller: "npm:^3.0.0"
-    configstore: "npm:^5.0.0"
-    gaxios: "npm:^2.0.0"
-    google-auth-library: "npm:^5.0.0"
-    pumpify: "npm:^2.0.0"
-    stream-events: "npm:^1.0.4"
-  bin:
-    gcs-upload: build/src/cli.js
-  checksum: 10/4ea5dbe537fa551fba822080b646b4f4df7f9063fd0cd5844a2508c75dde4541df4f5072d844bcf941a0d1cc264c7f2c7b43d77d3adef2538e92486bc95fcae0
+  checksum: 10/f6b1a604d5888db261a9a3ca0a494338b5cdbf815efa393aa38051d814387545bbfd9f25874bf8ea36441f2052625add42658e8973648e53f9b90f151b4bad1b
   languageName: node
   linkType: hard
 
@@ -15136,59 +15549,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^5.0.0, google-auth-library@npm:^5.5.0":
-  version: 5.10.1
-  resolution: "google-auth-library@npm:5.10.1"
+"google-auth-library@npm:^9.6.3":
+  version: 9.15.1
+  resolution: "google-auth-library@npm:9.15.1"
   dependencies:
-    arrify: "npm:^2.0.0"
     base64-js: "npm:^1.3.0"
     ecdsa-sig-formatter: "npm:^1.0.11"
-    fast-text-encoding: "npm:^1.0.0"
-    gaxios: "npm:^2.1.0"
-    gcp-metadata: "npm:^3.4.0"
-    gtoken: "npm:^4.1.0"
+    gaxios: "npm:^6.1.1"
+    gcp-metadata: "npm:^6.1.0"
+    gtoken: "npm:^7.0.0"
     jws: "npm:^4.0.0"
-    lru-cache: "npm:^5.0.0"
-  checksum: 10/30eb67763187de6b1ceb8bd1f4400c02ba7ed7081e1b066864d3a507a5652c79a30ef454efa78d234405531516794bb5b6c318b5a6db1c1df12baa48d5f9bbac
+  checksum: 10/6b977dd20f4f1ab6b2d2b78650d1e1c79ca84b951720b1064b85ebbb32af469547db7505a6609265e806be11c823bd6e07323b5073a98729b43b29fe34f05717
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^7.0.0, google-auth-library@npm:^7.14.0":
-  version: 7.14.1
-  resolution: "google-auth-library@npm:7.14.1"
-  dependencies:
-    arrify: "npm:^2.0.0"
-    base64-js: "npm:^1.3.0"
-    ecdsa-sig-formatter: "npm:^1.0.11"
-    fast-text-encoding: "npm:^1.0.0"
-    gaxios: "npm:^4.0.0"
-    gcp-metadata: "npm:^4.2.0"
-    gtoken: "npm:^5.0.4"
-    jws: "npm:^4.0.0"
-    lru-cache: "npm:^6.0.0"
-  checksum: 10/36e99d1376b4b447e4b174259a1902f4c9819a305f8737d4e94e2ac0bd6036a816473907c5518999d0ca86a325751ab589053a57d740743bae8330413f42a2ac
-  languageName: node
-  linkType: hard
-
-"google-p12-pem@npm:^2.0.0":
-  version: 2.0.5
-  resolution: "google-p12-pem@npm:2.0.5"
-  dependencies:
-    node-forge: "npm:^0.10.0"
-  bin:
-    gp12-pem: build/src/bin/gp12-pem.js
-  checksum: 10/2733eb7c6a374f0d58a778badbf954bc71804c7a7ad9c94e3677d35933d4ed3643ab186596d9c04bd366b55a945697404c12a8edeb17f8d62147704109e4241b
-  languageName: node
-  linkType: hard
-
-"google-p12-pem@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "google-p12-pem@npm:3.1.3"
-  dependencies:
-    node-forge: "npm:^1.0.0"
-  bin:
-    gp12-pem: build/src/bin/gp12-pem.js
-  checksum: 10/ce462a5d9c0afff0375da8c8cc1c143753597b7e2ab1f338a70638f92af31be6a42bc7d92debf0e92cb29e549c56925f27cbacd3330606dcc11c76a5cdde2303
+"google-logging-utils@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "google-logging-utils@npm:0.0.2"
+  checksum: 10/f8f5ec3087ef4563d12ee1afc603e6b42b4d703c1f10c9f37b3080e6f4a2e9554e0fd9dcdce97ded5a46ead465c706ff2bc791ad2ca478ed8dc62fdc4b06cac6
   languageName: node
   linkType: hard
 
@@ -15264,26 +15642,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gtoken@npm:^4.1.0":
-  version: 4.1.4
-  resolution: "gtoken@npm:4.1.4"
+"gtoken@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "gtoken@npm:7.1.0"
   dependencies:
-    gaxios: "npm:^2.1.0"
-    google-p12-pem: "npm:^2.0.0"
+    gaxios: "npm:^6.0.0"
     jws: "npm:^4.0.0"
-    mime: "npm:^2.2.0"
-  checksum: 10/3044b48ebe78bbb9432d4aa57608a27078a7eebcd4f95f526ca56af02eec8d17b5ca8e4f92821f824a07e3f311ada2a061b0c3a34b796023594db9bfa9b688f7
-  languageName: node
-  linkType: hard
-
-"gtoken@npm:^5.0.4":
-  version: 5.3.2
-  resolution: "gtoken@npm:5.3.2"
-  dependencies:
-    gaxios: "npm:^4.0.0"
-    google-p12-pem: "npm:^3.1.3"
-    jws: "npm:^4.0.0"
-  checksum: 10/357e78e6ad35154e8b291cf29237be9b636f946cd5eaa1c50317610a345048512a2023670273589d5b09585d5970ca782ac45ec12dee069cceab86bf836d8102
+  checksum: 10/640392261e55c9242137a81a4af8feb053b57061762cedddcbb6a0d62c2314316161808ac2529eea67d06d69fdc56d82361af50f2d840a04a87ea29e124d7382
   languageName: node
   linkType: hard
 
@@ -15388,13 +15753,6 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.1"
   checksum: 10/a449f3185b1d165026e8d25f6a8c3390bd25c201ff4b8c1aaf948fc6a5fcfd6507310b8c00c13a3325795ea9791fcc3d79d61eafa313b5750438fc19183df57b
-  languageName: node
-  linkType: hard
-
-"hash-stream-validation@npm:^0.2.2":
-  version: 0.2.4
-  resolution: "hash-stream-validation@npm:0.2.4"
-  checksum: 10/1ada816a51a64499d688bebc7ccf5b4f93df11422cd370d02efc493d80164aca7ad2d7487b88fb2f4fdc7f586c8b87dd3ae5ee92ef4eb2b986e5d26dbc5a413e
   languageName: node
   linkType: hard
 
@@ -15506,6 +15864,13 @@ __metadata:
   dependencies:
     whatwg-encoding: "npm:^1.0.5"
   checksum: 10/70365109cad69ee60376715fe0a56dd9ebb081327bf155cda93b2c276976c79cbedee2b988de6b0aefd0671a5d70597a35796e6e7d91feeb2c0aba46df059630
+  languageName: node
+  linkType: hard
+
+"html-entities@npm:^2.5.2":
+  version: 2.6.0
+  resolution: "html-entities@npm:2.6.0"
+  checksum: 10/06d4e7a3ba6243bba558af176e56f85e09894b26d911bc1ef7b2b9b3f18b46604360805b32636f080e954778e9a34313d1982479a05a5aa49791afd6a4229346
   languageName: node
   linkType: hard
 
@@ -15634,7 +15999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^4.0.0, http-proxy-agent@npm:^4.0.1":
+"http-proxy-agent@npm:^4.0.1":
   version: 4.0.1
   resolution: "http-proxy-agent@npm:4.0.1"
   dependencies:
@@ -15674,6 +16039,16 @@ __metadata:
     agent-base: "npm:6"
     debug: "npm:4"
   checksum: 10/517037badcbbe30757a9a88aaf5e8c198d31aa0b1e9c0a49a0053ab8e812809242218cc9ea1929171f74d95ae1ec89782ba471ffc3709b8910e91d1761f5f1a6
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.6
+  resolution: "https-proxy-agent@npm:7.0.6"
+  dependencies:
+    agent-base: "npm:^7.1.2"
+    debug: "npm:4"
+  checksum: 10/784b628cbd55b25542a9d85033bdfd03d4eda630fb8b3c9477959367f3be95dc476ed2ecbb9836c359c7c698027fc7b45723a302324433590f45d6c1706e8c13
   languageName: node
   linkType: hard
 
@@ -15906,7 +16281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
@@ -16328,13 +16703,6 @@ __metadata:
   version: 7.0.0
   resolution: "is-number@npm:7.0.0"
   checksum: 10/6a6c3383f68afa1e05b286af866017c78f1226d43ac8cb064e115ff9ed85eb33f5c4f7216c96a71e4dfea289ef52c5da3aef5bbfade8ffe47a0465d70c0c8e86
-  languageName: node
-  linkType: hard
-
-"is-obj@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-obj@npm:2.0.0"
-  checksum: 10/c9916ac8f4621962a42f5e80e7ffdb1d79a3fab7456ceaeea394cd9e0858d04f985a9ace45be44433bf605673c8be8810540fe4cc7f4266fc7526ced95af5a08
   languageName: node
   linkType: hard
 
@@ -17299,15 +17667,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-bigint@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "json-bigint@npm:0.3.1"
-  dependencies:
-    bignumber.js: "npm:^9.0.0"
-  checksum: 10/25f4c5195d6bc99bec723d93f2b630399a5a8b8e093fc36eb111884ecc3d533e85e99de3045451e19c161ccd7b246ebf73c8fd04d7d07c23bd5e2b4cfe820998
-  languageName: node
-  linkType: hard
-
 "json-bigint@npm:^1.0.0":
   version: 1.0.0
   resolution: "json-bigint@npm:1.0.0"
@@ -17945,7 +18304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^5.0.0, lru-cache@npm:^5.1.1":
+"lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
   dependencies:
@@ -18163,7 +18522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.51.0, mime-db@npm:>= 1.43.0 < 2":
+"mime-db@npm:1.51.0":
   version: 1.51.0
   resolution: "mime-db@npm:1.51.0"
   checksum: 10/cd541c90d4d0b5831aa99f41c02d5f5d28d64e8a4a55d88530e26f8cc663968c7d2ba3ee953d563ff87b0c03dfe21eed6e23feec36b92a1cbd0e3c71acc8859c
@@ -18181,15 +18540,6 @@ __metadata:
   version: 1.54.0
   resolution: "mime-db@npm:1.54.0"
   checksum: 10/9e7834be3d66ae7f10eaa69215732c6d389692b194f876198dca79b2b90cbf96688d9d5d05ef7987b20f749b769b11c01766564264ea5f919c88b32a29011311
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.0.8, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
-  version: 2.1.34
-  resolution: "mime-types@npm:2.1.34"
-  dependencies:
-    mime-db: "npm:1.51.0"
-  checksum: 10/6685d1123ec76b84ddfa0bd0f57e400eeb3caa6a2166f106eb3435b2570f35afe0b5b6f457efe0f63fe87a618f44ec10050a0b0637e1c64a4f20008f49b2effe
   languageName: node
   linkType: hard
 
@@ -18220,6 +18570,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
+  version: 2.1.34
+  resolution: "mime-types@npm:2.1.34"
+  dependencies:
+    mime-db: "npm:1.51.0"
+  checksum: 10/6685d1123ec76b84ddfa0bd0f57e400eeb3caa6a2166f106eb3435b2570f35afe0b5b6f457efe0f63fe87a618f44ec10050a0b0637e1c64a4f20008f49b2effe
+  languageName: node
+  linkType: hard
+
 "mime@npm:1.6.0":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
@@ -18229,7 +18588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:^2.0.3, mime@npm:^2.2.0, mime@npm:^2.4.4":
+"mime@npm:^2.0.3, mime@npm:^2.4.4":
   version: 2.6.0
   resolution: "mime@npm:2.6.0"
   bin:
@@ -19242,13 +19601,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.0":
-  version: 2.6.0
-  resolution: "node-fetch@npm:2.6.0"
-  checksum: 10/49604f97b69a23dccaaf5552f19d8a5a4896b1fdf5b8e085c4a3bc5602ba9a50bb11463c380b8cd08611d9fd320f30e692b60bd06b480f9a65bf1822857ecea7
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^1.0.1":
   version: 1.7.3
   resolution: "node-fetch@npm:1.7.3"
@@ -19259,7 +19611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.2.0, node-fetch@npm:^2.3.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -19273,17 +19625,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "node-forge@npm:0.10.0"
-  checksum: 10/16f5cab3a081af4d34991b20102d96f4aa37b4f57f79e3678d931b23359cdda14d5e988901146cd928ee90ffd2770ca75be1add267d7960703b5b4bcec4d858a
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "node-forge@npm:1.3.0"
-  checksum: 10/ce829501c839b0ed9b6d752d2166eff136fab60c309d32dbd900e5e2764b2d631d4e4519c2389da97ebb214dce3bc6962c9f288028e13ae070bc947d4110abbc
+"node-fetch@npm:^2.6.9":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
   languageName: node
   linkType: hard
 
@@ -19641,7 +19993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+"onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -20647,17 +20999,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pumpify@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "pumpify@npm:2.0.1"
-  dependencies:
-    duplexify: "npm:^4.1.1"
-    inherits: "npm:^2.0.3"
-    pump: "npm:^3.0.0"
-  checksum: 10/54bfdd04a30f459de5f1d1d022dc729e7257748900adf567a3b009f5aefe4a862ca91f3fb272f86c621eae631c4cc41f0efe5ee270752e2f9a90e7e63a9f8570
-  languageName: node
-  linkType: hard
-
 "punycode@npm:1.3.2":
   version: 1.3.2
   resolution: "punycode@npm:1.3.2"
@@ -21245,17 +21586,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:2 || 3, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10/b80b3e6a7fafb1c79de7db541de357f4a5ee73bd70c21672f5a7c840d27bb27bdb0151e7ba2fd82c4a888df22ce0c501b0d9f3e4dfe51688876701c437d59536
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
@@ -21268,6 +21598,17 @@ __metadata:
     string_decoder: "npm:~1.1.1"
     util-deprecate: "npm:~1.0.1"
   checksum: 10/d04c677c1705e3fc6283d45859a23f4c05243d0c0f1fc08cb8f995b4d69f0eb7f38ec0ec102f0ee20535c5d999ee27449f40aa2edf6bf30c24d0cc8f8efeb6d7
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1":
+  version: 3.6.0
+  resolution: "readable-stream@npm:3.6.0"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10/b80b3e6a7fafb1c79de7db541de357f4a5ee73bd70c21672f5a7c840d27bb27bdb0151e7ba2fd82c4a888df22ce0c501b0d9f3e4dfe51688876701c437d59536
   languageName: node
   linkType: hard
 
@@ -21846,13 +22187,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"retry-request@npm:^4.0.0, retry-request@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "retry-request@npm:4.2.2"
+"retry-request@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "retry-request@npm:7.0.2"
   dependencies:
-    debug: "npm:^4.1.1"
+    "@types/request": "npm:^2.48.8"
     extend: "npm:^3.0.2"
-  checksum: 10/0a01375f269b33cb707f043336062d62e1cbc3bd8f9adce94277f6388c11b6cf2037e09f3d0792510e605304a91b81d57d5f7b7f1aa4523278be0ad1c31754f2
+    teeny-request: "npm:^9.0.0"
+  checksum: 10/8f4c927d41dd575fc460aad7b762fb0a33542097201c3c1a31529ad17fa8af3ac0d2a45bf4a2024d079913e9c2dd431566070fe33321c667ac87ebb400de5917
   languageName: node
   linkType: hard
 
@@ -22796,13 +23138,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snakeize@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "snakeize@npm:0.1.0"
-  checksum: 10/7ec5e52991470592bead8308586d984872e1ae3e5380b7affd65c1ab6190112b53e1caa52c7ad0cd2b4eff9dae1868fd0b8a7743a56920855d5eb9491fc683f1
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "socks-proxy-agent@npm:5.0.0"
@@ -23096,7 +23431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-events@npm:^1.0.1, stream-events@npm:^1.0.4, stream-events@npm:^1.0.5":
+"stream-events@npm:^1.0.5":
   version: 1.0.5
   resolution: "stream-events@npm:1.0.5"
   dependencies:
@@ -23105,10 +23440,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-shift@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "stream-shift@npm:1.0.1"
-  checksum: 10/59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
+"stream-shift@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "stream-shift@npm:1.0.3"
+  checksum: 10/a24c0a3f66a8f9024bd1d579a533a53be283b4475d4e6b4b3211b964031447bdf6532dd1f3c2b0ad66752554391b7c62bd7ca4559193381f766534e723d50242
   languageName: node
   linkType: hard
 
@@ -23400,6 +23735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^1.0.5":
+  version: 1.1.2
+  resolution: "strnum@npm:1.1.2"
+  checksum: 10/ccd6297a1fdaf0fc8ea0ea904acdae76878d49a4b0d98a70155df4bc081fd88eac5ec99fb150f3d1d1af065c1898d38420705259ba6c39aa850c671bcd54e35d
+  languageName: node
+  linkType: hard
+
 "strtok3@npm:^10.3.4":
   version: 10.3.5
   resolution: "strtok3@npm:10.3.5"
@@ -23651,29 +23993,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"teeny-request@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "teeny-request@npm:6.0.3"
-  dependencies:
-    http-proxy-agent: "npm:^4.0.0"
-    https-proxy-agent: "npm:^5.0.0"
-    node-fetch: "npm:^2.2.0"
-    stream-events: "npm:^1.0.5"
-    uuid: "npm:^7.0.0"
-  checksum: 10/b1b48af0a8bc810386852ba261d7d4b3f3b2a1a90d175656749e7ced0928e5a8f39e112e0980777c08b13cd6b7439683d9b1127b8406af67c70d31333570d6ad
-  languageName: node
-  linkType: hard
-
-"teeny-request@npm:^7.0.0":
-  version: 7.1.3
-  resolution: "teeny-request@npm:7.1.3"
+"teeny-request@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "teeny-request@npm:9.0.0"
   dependencies:
     http-proxy-agent: "npm:^5.0.0"
     https-proxy-agent: "npm:^5.0.0"
-    node-fetch: "npm:^2.6.1"
+    node-fetch: "npm:^2.6.9"
     stream-events: "npm:^1.0.5"
-    uuid: "npm:^8.0.0"
-  checksum: 10/ceae5f252dc711979e822cf516c7b3695c5d6137468b344c707cb86b21cd1dcf0314b235ae5ce79481f7fb2c95ee274dcc70b3584f3593914ce7f62b7e2af73a
+    uuid: "npm:^9.0.0"
+  checksum: 10/44daabb6c2e239c3daed0218ebdafb50c7141c16d7257a6cfef786dbff56d7853c2c02c97934f7ed57818ce5861ac16c5f52f3a16fa292bd4caf53483d386443
   languageName: node
   linkType: hard
 
@@ -23825,16 +24154,6 @@ __metadata:
   version: 6.0.1
   resolution: "throat@npm:6.0.1"
   checksum: 10/b4788024c17e2e9c0d5773434fe16b6de98ccfc413ab8ed4ac2230d84a0af724fc12434453c31bf9b032f4c1910b95376d7fc1410786695d26d3bed49cb6ac55
-  languageName: node
-  linkType: hard
-
-"through2@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "through2@npm:3.0.2"
-  dependencies:
-    inherits: "npm:^2.0.4"
-    readable-stream: "npm:2 || 3"
-  checksum: 10/98bdffba8e877fd8beb2154adc4eb0d52fad281130f56f6e5d18f85d1e1aa528a7b27317b302eb5443f6636ab045d3c272e6dffc61d984775db284823b90532d
   languageName: node
   linkType: hard
 
@@ -24127,7 +24446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.4.0, tslib@npm:^2.6.3, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2.8.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -24491,15 +24810,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-string@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "unique-string@npm:2.0.0"
-  dependencies:
-    crypto-random-string: "npm:^2.0.0"
-  checksum: 10/107cae65b0b618296c2c663b8e52e4d1df129e9af04ab38d53b4f2189e96da93f599c85f4589b7ffaf1a11c9327cbb8a34f04c71b8d4950d3e385c2da2a93828
-  languageName: node
-  linkType: hard
-
 "universal-cookie@npm:4.0.4, universal-cookie@npm:^4.0.4":
   version: 4.0.4
   resolution: "universal-cookie@npm:4.0.4"
@@ -24697,16 +25007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "uuid@npm:7.0.3"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/b2a4d30ecd6581015175487426558aafd7f7b4013a2e30802c128cc28cad9abe46ecd36c02f7fbcde7908fd4672334818d56a441c0871963d6bd89d911bef2ea
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
+"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
   bin:
@@ -25291,13 +25592,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/745fc1a1cdac7e91f2c7340f7006aea06454b6ca4f24615a1e81124f46d99a7200839895c088a30c1d8d92dd1a9d349046bd4bc3475447aaf13b1f5cb48a18b7
-  languageName: node
-  linkType: hard
-
-"xdg-basedir@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "xdg-basedir@npm:4.0.0"
-  checksum: 10/0073d5b59a37224ed3a5ac0dd2ec1d36f09c49f0afd769008a6e9cd3cd666bd6317bd1c7ce2eab47e1de285a286bad11a9b038196413cd753b79770361855f3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Таска
- Close atls/planning#649

## Как проверять
### До фикса
1. Контекст: runtime-зависимости файлового сервиса, public gateway, site renderer и search service.
Действие: проверить manifests и lock на `@monstrs/nestjs-signed-url`, `@monstrs/oathkeeper-auth`, `@monstrs/nestjs-elasticsearch-indicator`.
Ожидаемый результат: старые runtime-пакеты `@monstrs` присутствуют в контуре и удерживают legacy-зависимости.

### После фикса
1. Контекст: runtime dependency cleanup для оставшихся `@monstrs` пакетов.
Действие: проверить manifests, `.yarnrc.yml`, `yarn.lock` и PnP после перехода на ATLS Ory/Signed URL пакеты.
Ожидаемый результат: `@monstrs/nestjs-signed-url`, `@monstrs/oathkeeper-auth` и `@monstrs/nestjs-elasticsearch-indicator` отсутствуют в runtime manifests и lock.

2. Контекст: затронутые workspace после замены зависимостей.
Действие: собрать `@files/service`, `@public-gateway/app`, `@search/service`, `@site/renderer-entrypoint` штатными Yarn/Raijin командами.
Ожидаемый результат: все четыре workspace собираются без прямых обходных запусков.

## Пруфы
- `yarn install --immutable`: проходит
- `git diff --check`: проходит
- `rg -n "@monstrs/(nestjs-signed-url|nestjs-elasticsearch-indicator|oathkeeper-auth)|@monstrs/oathkeeper-auth|@monstrs/nestjs-signed-url|@monstrs/nestjs-elasticsearch-indicator" files search public-gateway site package.json .yarnrc.yml yarn.lock -S`: matches отсутствуют
- `yarn workspace @files/service build`: проходит
- `yarn workspace @public-gateway/app build`: проходит
- `yarn workspace @search/service build`: проходит
- `yarn workspace @site/renderer-entrypoint build`: проходит
- `yarn check`: завершается с exit `0`; нерелевантный formatter output откачен из PR
